### PR TITLE
Add methods needed to create and finalize a credential value builder

### DIFF
--- a/pkg/libursa/ursa/ursa_cl.h
+++ b/pkg/libursa/ursa/ursa_cl.h
@@ -215,6 +215,79 @@ struct ExternError ursa_cl_signature_correctness_proof_to_json(const void *signa
 struct ExternError ursa_cl_credential_signature_free(const void *credential_signature);
 
 /**
+ * Adds new hidden attribute dec_value to credential values map.
+ *
+ * # Arguments
+ * * `credential_values_builder` - Reference that contains credential values builder instance pointer.
+ * * `attr` - Credential attr to add as null terminated string.
+ * * `dec_value` - Credential attr dec_value. Decimal BigNum representation as null terminated string.
+ * * `dec_blinding_factor` - Credential blinding factor. Decimal BigNum representation as null terminated string
+ */
+struct ExternError ursa_cl_credential_values_builder_add_dec_commitment(const void *credential_values_builder,
+                                                               const char *attr,
+                                                               const char *dec_value,
+                                                               const char *dec_blinding_factor);
+
+/**
+ * Adds new hidden attribute dec_value to credential values map.
+ *
+ * # Arguments
+ * * `credential_values_builder` - Reference that contains credential values builder instance pointer.
+ * * `attr` - Credential attr to add as null terminated string.
+ * * `dec_value` - Credential attr dec_value. Decimal BigNum representation as null terminated string.
+ */
+struct ExternError ursa_cl_credential_values_builder_add_dec_hidden(const void *credential_values_builder,
+                                                           const char *attr,
+                                                           const char *dec_value);
+
+/**
+ * Adds new known attribute dec_value to credential values map.
+ *
+ * # Arguments
+ * * `credential_values_builder` - Reference that contains credential values builder instance pointer.
+ * * `attr` - Credential attr to add as null terminated string.
+ * * `dec_value` - Credential attr dec_value. Decimal BigNum representation as null terminated string.
+ */
+struct ExternError ursa_cl_credential_values_builder_add_dec_known(const void *credential_values_builder,
+                                                          const char *attr,
+                                                          const char *dec_value);
+
+/**
+ * Deallocates credential values builder and returns credential values entity instead.
+ *
+ * Note: Credentials values instance deallocation must be performed by
+ * calling ursa_cl_credential_values_free.
+ *
+ * # Arguments
+ * * `credential_values_builder` - Reference that contains credential attribute builder instance pointer.
+ * * `credential_values_p` - Reference that will contain credentials values instance pointer.
+ */
+struct ExternError ursa_cl_credential_values_builder_finalize(const void *credential_values_builder,
+                                                     const void **credential_values_p);
+
+/**
+ * Creates and returns credentials values entity builder.
+ *
+ * The purpose of credential values builder is building of credential values entity that
+ * represents credential attributes values map.
+ *
+ * Note: Credentials values builder instance deallocation must be performed by
+ * calling ursa_cl_credential_values_builder_finalize.
+ *
+ * # Arguments
+ * * `credential_values_builder_p` - Reference that will contain credentials values builder instance pointer.
+ */
+struct ExternError ursa_cl_credential_values_builder_new(const void **credential_values_builder_p);
+
+/**
+ * Deallocates credential values instance.
+ *
+ * # Arguments
+ * * `credential_values` - Credential values instance pointer
+ */
+struct ExternError ursa_cl_credential_values_free(const void *credential_values);
+
+/**
  * Creates and returns credential definition (public and private keys, correctness proof) entities.
  *
  * Note that credential public key instances deallocation must be performed by

--- a/pkg/libursa/ursa/value_builder.go
+++ b/pkg/libursa/ursa/value_builder.go
@@ -1,0 +1,93 @@
+package ursa
+
+/*
+   #cgo LDFLAGS: -lursa
+   #include "ursa_cl.h"
+   #include <stdlib.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+// NewValuesBuilder creates and returns credentials values entity builder
+func NewValueBuilder() (unsafe.Pointer, error) {
+	var builder unsafe.Pointer
+
+	result := C.ursa_cl_credential_values_builder_new(&builder)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return builder, nil
+}
+
+// AddDecHidden adds new hidden attribute dec_value to credential values map
+func AddDecHidden(builder unsafe.Pointer, attr, decValue string) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+
+	cval := C.CString(decValue)
+	defer C.free(unsafe.Pointer(cval))
+
+	result := C.ursa_cl_credential_values_builder_add_dec_hidden(builder, cattr, cval)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+// AddDecKnown adds new known attribute dec_value to credential values map
+func AddDecKnown(builder unsafe.Pointer, attr, decValue string) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+	cval := C.CString(decValue)
+	defer C.free(unsafe.Pointer(cval))
+
+	result := C.ursa_cl_credential_values_builder_add_dec_known(builder, cattr, cval)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+// AddDecCommitment adds new hidden attribute dec_value to credential values map
+func AddDecCommitment(builder unsafe.Pointer, attr, decValue, decBlindingFactor string) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+	cval := C.CString(decValue)
+	defer C.free(unsafe.Pointer(cval))
+	cfac := C.CString(decBlindingFactor)
+	defer C.free(unsafe.Pointer(cfac))
+
+	result := C.ursa_cl_credential_values_builder_add_dec_commitment(builder, cattr, cval, cfac)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+
+	return nil
+}
+
+// FinalizeBuilder deallocates credential values builder and returns credential values entity instead
+func FinalizeBuilder(builder unsafe.Pointer) (unsafe.Pointer, error) {
+	var values unsafe.Pointer
+	result := C.ursa_cl_credential_values_builder_finalize(builder, &values)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return values, nil
+}
+
+// FreeCredentialValues deallocates credential values instance
+func FreeCredentialValues(values unsafe.Pointer) error {
+	result := C.ursa_cl_credential_values_free(values)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}

--- a/pkg/libursa/ursa/value_builder_test.go
+++ b/pkg/libursa/ursa/value_builder_test.go
@@ -1,0 +1,83 @@
+package ursa
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewValueBuilder(t *testing.T) {
+	t.Run("NewValueBuilder", func(t *testing.T) {
+		builder, err := NewValueBuilder()
+		assert.Empty(t, err)
+		assert.NotEmpty(t, builder)
+	})
+}
+
+func TestAddDecHidden(t *testing.T) {
+	t.Run("AddDecHidden", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecHidden(builder, "master_secret", "122345")
+		assert.Empty(t, err)
+	})
+
+	t.Run("AddDecHidden", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecHidden(builder, "master_secret", "fail")
+		assert.NotEmpty(t, err)
+	})
+}
+
+func TestAddDecKnown(t *testing.T) {
+	t.Run("AddDecKnown", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecKnown(builder, "master_secret", "12a2345")
+		assert.Empty(t, err)
+	})
+
+	t.Run("AddDecKnown", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecKnown(builder, "master_secret", "fail")
+		assert.NotEmpty(t, err)
+	})
+}
+
+func TestAddDecCommitment(t *testing.T) {
+	t.Run("AddDecCommitment", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecCommitment(builder, "master_secret", "12345", "9876")
+		assert.Empty(t, err)
+	})
+
+	t.Run("AddDecCommitment", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		err := AddDecCommitment(builder, "master_secret", "fail", "9876")
+		assert.NotEmpty(t, err)
+	})
+}
+
+func TestFinalizeBuilder(t *testing.T) {
+	t.Run("FinalizeBuilder", func(t *testing.T) {
+		builder, _ := NewValueBuilder()
+
+		values, err := FinalizeBuilder(builder)
+		assert.Empty(t, err)
+		assert.NotEmpty(t, values)
+	})
+}
+
+func TestFreeCredentialValues(t *testing.T) {
+	t.Run("FreeCredentialValues", func(t *testing.T) {
+		var values unsafe.Pointer
+
+		err := FreeCredentialValues(values)
+		assert.NotEmpty(t, err)
+	})
+}


### PR DESCRIPTION
Signed-off-by: Mikaela <mikaela@scoir.com>

Summary:
Wrapped neccesary methods needed for credential value builder including:
- `ursa_cl_credential_values_builder_new`
- `ursa_cl_credential_values_builder_finalize`
- `ursa_cl_credential_values_builder_add_dec_known`
- `ursa_cl_credential_values_builder_add_dec_hidden`
- `ursa_cl_credential_values_builder_add_dec_commitment`
- `ursa_cl_credential_values_free`