### PR TITLE
Wrap public and private key to-json methods

### DIFF
--- a/pkg/libursa/ursa/ursa_cl.h
+++ b/pkg/libursa/ursa/ursa_cl.h
@@ -215,6 +215,26 @@ struct ExternError ursa_cl_signature_correctness_proof_to_json(const void *signa
 struct ExternError ursa_cl_credential_signature_free(const void *credential_signature);
 
 /**
+ * Returns json representation of credential public key.
+ *
+ * # Arguments
+ * * `credential_pub_key` - Reference that contains credential public key instance pointer.
+ * * `credential_pub_key_p` - Reference that will contain credential public key json.
+ */
+struct ExternError ursa_cl_credential_public_key_to_json(const void *credential_pub_key,
+                                                const char **credential_pub_key_json_p);
+
+/**
+ * Returns json representation of credential key correctness proof.
+ *
+ * # Arguments
+ * * `credential_key_correctness_proof` - Reference that contains credential key correctness proof instance pointer.
+ * * `credential_key_correctness_proof_p` - Reference that will contain credential key correctness proof json.
+ */
+struct ExternError ursa_cl_credential_key_correctness_proof_to_json(const void *credential_key_correctness_proof,
+                                                           const char **credential_key_correctness_proof_json_p);
+
+/**
  * Adds new attribute to non credential schema.
  *
  * # Arguments
@@ -427,3 +447,13 @@ struct ExternError ursa_cl_credential_private_key_free(const void *credential_pr
  * * `credential_pub_key` - Reference that contains credential public key instance pointer.
  */
 struct ExternError ursa_cl_credential_public_key_free(const void *credential_pub_key);
+
+/**
+ * Returns json representation of credential private key.
+ *
+ * # Arguments
+ * * `credential_priv_key` - Reference that contains credential private key instance pointer.
+ * * `credential_pub_key_p` - Reference that will contain credential private key json.
+ */
+struct ExternError ursa_cl_credential_private_key_to_json(const void *credential_priv_key,
+                                                 const char **credential_priv_key_json_p);

--- a/pkg/libursa/ursa/ursa_test.go
+++ b/pkg/libursa/ursa/ursa_test.go
@@ -100,9 +100,10 @@ func TestCredentialPublicKeyFromJSON(t *testing.T) {
 func TestSignCredential(t *testing.T) {
 	signParams := NewSignatureParams()
 
-	sig, err := signParams.SignCredential()
+	sig, proof, err := signParams.SignCredential()
 	assert.NotEmpty(t, err)
 	assert.Empty(t, sig)
+	assert.Empty(t, proof)
 }
 
 func TestCorrectnessProofToJSON(t *testing.T) {
@@ -211,7 +212,45 @@ func TestFreeCredentialPublicKey(t *testing.T) {
 func TestFreeCredentialKeyCorrectnessProof(t *testing.T) {
 	t.Run("FreeCredentialKeyCorrectnessProof", func(t *testing.T) {
 		var proof unsafe.Pointer
-		err := FreeCredentialSchema(proof)
+		err := FreeCredentialKeyCorrectnessProof(proof)
 		assert.NotEmpty(t, err)
+	})
+}
+
+func TestCredentialPublicKeyToJSON(t *testing.T) {
+	t.Run("CredentialPublicKeyToJSON", func(t *testing.T) {
+		schemaBuilder, _ := CredentialSchemaBuilderNew()
+		_ = CredentialSchemaBuilderAddAttr(schemaBuilder,"master_secret")
+		schema, _ := CredentialSchemaBuilderFinalize(schemaBuilder)
+
+		nonSchemaBuilder, _ := NonCredentialSchemaBuilderNew()
+		_ = NonCredentialSchemaBuilderAddAttr(nonSchemaBuilder, "master_secret")
+		nonSchema, _ := NonCredentialSchemaBuilderFinalize(nonSchemaBuilder)
+
+		credDef, _ := NewCredentialDef(schema, nonSchema, false)
+
+		pubKey, err := CredentialPublicKeyToJSON(credDef.PubKey)
+
+		assert.Empty(t, err)
+		assert.NotEmpty(t, pubKey)
+	})
+}
+
+func TestCredentialPrivateKeyToJSON(t *testing.T) {
+	t.Run("CredentialPrivateKeyToJSON", func(t *testing.T) {
+		schemaBuilder, _ := CredentialSchemaBuilderNew()
+		_ = CredentialSchemaBuilderAddAttr(schemaBuilder,"master_secret")
+		schema, _ := CredentialSchemaBuilderFinalize(schemaBuilder)
+
+		nonSchemaBuilder, _ := NonCredentialSchemaBuilderNew()
+		_ = NonCredentialSchemaBuilderAddAttr(nonSchemaBuilder, "master_secret")
+		nonSchema, _ := NonCredentialSchemaBuilderFinalize(nonSchemaBuilder)
+
+		credDef, _ := NewCredentialDef(schema, nonSchema, false)
+
+		privKey, err := CredentialPrivateKeyToJSON(credDef.PrivKey)
+
+		assert.Empty(t, err)
+		assert.NotEmpty(t, privKey)
 	})
 }


### PR DESCRIPTION
Signed-off-by: Mikaela <mikaela@scoir.com>

**Title:**
Wrapped ToJSON methods 

Summary:
Wrapped ToJSON methods for public and private keys and added ToJSON method for KeyCorrectnessProof in SignCredential. 
