### PR TITLE
Wrapper for signing credentials and generating proofs. 

### DIFF
--- a/pkg/libursa/ursa/credential_definition_test.go
+++ b/pkg/libursa/ursa/credential_definition_test.go
@@ -1,0 +1,131 @@
+package ursa
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCredentialDefinition(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		fields := []string{"attr1", "attr2", "attr3"}
+		var nonfields []string
+
+		credDef := createCredentialDefinition(t, fields, nonfields)
+
+		pubKeyJSON, err := credDef.PubKey.ToJSON()
+		assert.NoError(t, err)
+		m := map[string]interface{}{}
+		err = json.Unmarshal(pubKeyJSON, &m)
+		assert.NoError(t, err)
+
+		pkey, ok := m["p_key"].(map[string]interface{})
+		assert.True(t, ok)
+
+		r, ok := pkey["r"].(map[string]interface{})
+		assert.True(t, ok)
+
+		for _, field := range fields {
+			x, ok := r[field].(string)
+			assert.True(t, ok)
+			i := new(big.Int)
+			_, ok = i.SetString(x, 10)
+			assert.True(t, ok)
+		}
+
+		privKeyJSON, err := credDef.PrivKey.ToJSON()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, privKeyJSON)
+
+		correctnessJSON, err := credDef.PubKey.ToJSON()
+		assert.NoError(t, err)
+
+		m = map[string]interface{}{}
+		err = json.Unmarshal(correctnessJSON, &m)
+		assert.NoError(t, err)
+
+		pkey, ok = m["p_key"].(map[string]interface{})
+		assert.True(t, ok)
+
+		r, ok = pkey["r"].(map[string]interface{})
+		assert.True(t, ok)
+
+		for _, field := range fields {
+			x, ok := r[field].(string)
+			assert.True(t, ok)
+			i := new(big.Int)
+			_, ok = i.SetString(x, 10)
+			assert.True(t, ok)
+		}
+
+		err = credDef.PubKey.Free()
+		assert.NoError(t, err)
+
+		err = credDef.PrivKey.Free()
+		assert.NoError(t, err)
+
+		err = credDef.KeyCorrectnessProof.Free()
+		assert.NoError(t, err)
+	})
+}
+
+func createCredentialDefinition(t *testing.T, fields, nonfields []string) *CredentialDef {
+
+	fields = append(fields, "master_secret")
+
+	schema := createSchema(t, fields)
+
+	nonschema := createNonSchema(t, nonfields)
+
+	credDef, err := NewCredentialDef(schema, nonschema, false)
+	assert.NoError(t, err)
+
+	return credDef
+}
+
+func createSchema(t *testing.T, fields []string) *CredentialSchemaHandle {
+	schemaBuilder, err := NewCredentialSchemaBuilder()
+	assert.NoError(t, err)
+
+	for _, field := range fields {
+		err = schemaBuilder.AddAttr(field)
+		assert.NoError(t, err)
+	}
+
+	schema, err := schemaBuilder.Finalize()
+	assert.NoError(t, err)
+
+	return schema
+}
+
+func createNonSchema(t *testing.T, fields []string) *NonCredentialSchemaHandle {
+	nonSchemaBuilder, err := NewNonCredentialSchemaBuilder()
+	assert.NoError(t, err)
+
+	for _, field := range fields {
+		err = nonSchemaBuilder.AddAttr(field)
+		assert.NoError(t, err)
+	}
+
+	nonSchema, err := nonSchemaBuilder.Finalize()
+	assert.NoError(t, err)
+
+	return nonSchema
+}
+
+func createValues(t *testing.T, values map[string]interface{}) *CredentialValues {
+	builder, err := NewValueBuilder()
+	assert.NoError(t, err)
+
+	for k, v := range values {
+		err = builder.AddDecKnown(k, EncodeValue(v))
+		assert.NoError(t, err)
+	}
+
+	value, err := builder.Finalize()
+	assert.NoError(t, err)
+
+	return value
+}

--- a/pkg/libursa/ursa/master_secret.go
+++ b/pkg/libursa/ursa/master_secret.go
@@ -1,0 +1,60 @@
+package ursa
+
+/*
+   #cgo LDFLAGS: -lursa
+   #include "ursa_cl.h"
+   #include <stdlib.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+type MasterSecret Handle
+
+func NewMasterSecret() (*MasterSecret, error) {
+	var ms unsafe.Pointer
+
+	result := C.ursa_cl_prover_new_master_secret(&ms)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &MasterSecret{ms}, nil
+}
+
+//MasterSecretFromJson creates and returns nonce json
+func MasterSecretFromJSON(jsn []byte) (*MasterSecret, error) {
+	var handle unsafe.Pointer
+	cjson := C.CString(string(jsn))
+	defer C.free(unsafe.Pointer(cjson))
+
+	result := C.ursa_cl_master_secret_from_json(cjson, &handle)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &MasterSecret{handle}, nil
+}
+
+func (r *MasterSecret) ToJSON() ([]byte, error) {
+	var d *C.char
+	defer C.free(unsafe.Pointer(d))
+
+	result := C.ursa_cl_master_secret_to_json(r.ptr, &d)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	out := []byte(C.GoString(d))
+	return out, nil
+}
+
+func (r *MasterSecret) Free() error {
+	result := C.ursa_cl_master_secret_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}

--- a/pkg/libursa/ursa/master_secret_test.go
+++ b/pkg/libursa/ursa/master_secret_test.go
@@ -1,0 +1,42 @@
+package ursa
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMasterSecret(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		ms, err := NewMasterSecret()
+		assert.NoError(t, err)
+
+		js, err := ms.ToJSON()
+		assert.NoError(t, err)
+
+		m := struct {
+			MasterSecret string `json:"ms"`
+		}{}
+		err = json.Unmarshal(js, &m)
+		assert.NoError(t, err)
+
+		i := new(big.Int)
+		_, ok := i.SetString(m.MasterSecret, 10)
+		assert.True(t, ok)
+
+		ms, err = MasterSecretFromJSON(js)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ms)
+
+		err = ms.Free()
+		assert.NoError(t, err)
+	})
+
+	t.Run("bad json", func(t *testing.T) {
+		ms, err := MasterSecretFromJSON([]byte(`{"t": "123"}`))
+		assert.Error(t, err)
+		assert.Empty(t, ms)
+	})
+}

--- a/pkg/libursa/ursa/proof_builder.go
+++ b/pkg/libursa/ursa/proof_builder.go
@@ -1,0 +1,155 @@
+package ursa
+
+/*
+   #cgo LDFLAGS: -lursa
+   #include "ursa_cl.h"
+   #include <stdlib.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+type ProofBuilder Handle
+type ProofHandle Handle
+
+func NewProofBuilder() (*ProofBuilder, error) {
+	var builder unsafe.Pointer
+
+	result := C.ursa_cl_prover_new_proof_builder(&builder)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &ProofBuilder{builder}, nil
+}
+
+func ProofFromJSON(jsn []byte) (*ProofHandle, error) {
+	var builder unsafe.Pointer
+	cjson := C.CString(string(jsn))
+	defer C.free(unsafe.Pointer(cjson))
+
+	result := C.ursa_cl_proof_from_json(cjson, &builder)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &ProofHandle{builder}, nil
+}
+
+func (r *ProofBuilder) AddCommonAttribute(attr string) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+
+	result := C.ursa_cl_proof_builder_add_common_attribute(r.ptr, cattr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *ProofBuilder) AddSubProofRequest(subProof *SubProofRequestHandle, credSchema *CredentialSchemaHandle,
+	nonCredSchema *NonCredentialSchemaHandle, signature *CredentialSignature, values *CredentialValues, pubKey *CredentialDefPubKey) error {
+
+	result := C.ursa_cl_proof_builder_add_sub_proof_request(r.ptr, subProof.ptr, credSchema.ptr, nonCredSchema.ptr,
+		signature.ptr, values.ptr, pubKey.ptr /*revoc_reg*/, nil /*witness*/, nil)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *ProofBuilder) Finalize(nonce *Nonce) (*ProofHandle, error) {
+	var proof unsafe.Pointer
+
+	result := C.ursa_cl_proof_builder_finalize(r.ptr, nonce.ptr, &proof)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &ProofHandle{proof}, nil
+}
+
+func (r *ProofHandle) ToJSON() ([]byte, error) {
+	var d *C.char
+	defer C.free(unsafe.Pointer(d))
+
+	result := C.ursa_cl_proof_to_json(r.ptr, &d)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(d)), nil
+}
+
+func (r *ProofHandle) Free() error {
+	result := C.ursa_cl_proof_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+type SubProofRequestBuilder Handle
+type SubProofRequestHandle Handle
+
+func NewSubProofRequestBuilder() (*SubProofRequestBuilder, error) {
+	var builder unsafe.Pointer
+
+	result := C.ursa_cl_sub_proof_request_builder_new(&builder)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &SubProofRequestBuilder{builder}, nil
+
+}
+
+func (r *SubProofRequestBuilder) AddPredicate(attr, ptype string, value int32) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+	cptype := C.CString(ptype)
+	defer C.free(unsafe.Pointer(cptype))
+
+	result := C.ursa_cl_sub_proof_request_builder_add_predicate(r.ptr, cattr, cptype, C.int32_t(value))
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *SubProofRequestBuilder) AddRevealedAttr(attr string) error {
+	cattr := C.CString(attr)
+	defer C.free(unsafe.Pointer(cattr))
+
+	result := C.ursa_cl_sub_proof_request_builder_add_revealed_attr(r.ptr, cattr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *SubProofRequestBuilder) Finalize() (*SubProofRequestHandle, error) {
+	var proof unsafe.Pointer
+
+	result := C.ursa_cl_sub_proof_request_builder_finalize(r.ptr, &proof)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &SubProofRequestHandle{proof}, nil
+}
+
+func (r *SubProofRequestHandle) Free() error {
+	result := C.ursa_cl_sub_proof_request_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}

--- a/pkg/libursa/ursa/proof_builder_test.go
+++ b/pkg/libursa/ursa/proof_builder_test.go
@@ -1,0 +1,145 @@
+package ursa
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProofBuilder(t *testing.T) {
+	t.Run("basic proof builder", func(t *testing.T) {
+		pb, err := NewProofBuilder()
+		assert.NoError(t, err)
+
+		err = pb.AddCommonAttribute("master_secret")
+		assert.NoError(t, err)
+
+		nonce, err := NewNonce()
+		assert.NoError(t, err)
+
+		proof, err := pb.Finalize(nonce)
+		assert.NoError(t, err)
+
+		str, err := proof.ToJSON()
+		assert.NoError(t, err)
+
+		err = nonce.Free()
+		assert.NoError(t, err)
+
+		err = proof.Free()
+		assert.NoError(t, err)
+
+		newProof, err := ProofFromJSON(str)
+		assert.NoError(t, err)
+		assert.NotNil(t, newProof)
+
+	})
+
+	t.Run("with sub proof request", func(t *testing.T) {
+		fields := []string{"attr1", "attr2", "attr3"}
+		vals := map[string]interface{}{
+			"attr1": "val1",
+			"attr2": "val2",
+			"attr3": "val3",
+		}
+
+		pb, err := NewProofBuilder()
+		assert.NoError(t, err)
+
+		err = pb.AddCommonAttribute("first_name")
+		assert.NoError(t, err)
+
+		subProofBuilder, err := NewSubProofRequestBuilder()
+		assert.NoError(t, err)
+
+		for _, field := range fields {
+			err = subProofBuilder.AddRevealedAttr(field)
+			assert.NoError(t, err)
+		}
+
+		subProof, err := subProofBuilder.Finalize()
+
+		schema := createSchema(t, fields)
+
+		var nonSchemaFields []string
+		nonSchema := createNonSchema(t, nonSchemaFields)
+
+		credDef, err := NewCredentialDef(schema, nonSchema, false)
+		assert.NoError(t, err)
+
+		values := createValues(t, vals)
+		sig, _ := createSignature(t, fields, vals)
+
+		err = pb.AddSubProofRequest(subProof, schema, nonSchema, sig, values, credDef.PubKey)
+		assert.NoError(t, err)
+
+		nonce, err := NewNonce()
+		assert.NoError(t, err)
+
+		proof, err := pb.Finalize(nonce)
+		assert.NoError(t, err)
+
+		str, err := proof.ToJSON()
+		assert.NoError(t, err)
+
+		result := map[string]interface{}{}
+		err = json.Unmarshal(str, &result)
+		assert.NoError(t, err)
+
+		proofs, ok := result["proofs"].([]interface{})
+		assert.True(t, ok)
+
+		pp, ok := proofs[0].(map[string]interface{})
+		assert.True(t, ok)
+
+		primary, ok := pp["primary_proof"].(map[string]interface{})
+		assert.True(t, ok)
+
+		eq, ok := primary["eq_proof"].(map[string]interface{})
+		assert.True(t, ok)
+
+		revealed, ok := eq["revealed_attrs"].(map[string]interface{})
+		assert.True(t, ok)
+
+		for _, field := range fields {
+			x, ok := revealed[field].(string)
+			assert.True(t, ok)
+			i := new(big.Int)
+			_, ok = i.SetString(x, 10)
+			assert.True(t, ok)
+		}
+
+		err = nonce.Free()
+		assert.NoError(t, err)
+
+		err = subProof.Free()
+		assert.NoError(t, err)
+
+		newProof, err := ProofFromJSON(str)
+		assert.NoError(t, err)
+		assert.NotNil(t, newProof)
+
+		err = values.Free()
+		assert.NoError(t, err)
+
+	})
+}
+
+func TestSubProofRequest(t *testing.T) {
+	t.Run("basic subproof", func(t *testing.T) {
+		builder, err := NewSubProofRequestBuilder()
+		assert.NoError(t, err)
+
+		err = builder.AddRevealedAttr("name")
+		assert.NoError(t, err)
+
+		proof, err := builder.Finalize()
+		assert.NoError(t, err)
+		assert.NotNil(t, proof)
+
+		err = proof.Free()
+		assert.NoError(t, err)
+	})
+}

--- a/pkg/libursa/ursa/ursa.go
+++ b/pkg/libursa/ursa/ursa.go
@@ -13,30 +13,26 @@ import (
 	"github.com/pkg/errors"
 )
 
+type Handle struct {
+	ptr unsafe.Pointer
+}
+
+type Nonce Handle
+
 //NewNonce creates a random nonce
-func NewNonce() (string, error) {
+func NewNonce() (*Nonce, error) {
 	var nonce unsafe.Pointer
-	defer C.free(nonce)
 
 	result := C.ursa_cl_new_nonce(&nonce)
 	if result.code != 0 {
-		return "", ursaError(C.GoString(result.message))
-	}
-	defer C.ursa_cl_nonce_free(nonce)
-
-	var d *C.char
-	defer C.free(unsafe.Pointer(d))
-
-	result = C.ursa_cl_nonce_to_json(nonce, &d)
-	if result.code != 0 {
-		return "", ursaError(C.GoString(result.message))
+		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return C.GoString(d), nil
+	return &Nonce{nonce}, nil
 }
 
 //NonceFromJson creates and returns nonce json
-func NonceFromJson(jsn string) (unsafe.Pointer, error) {
+func NonceFromJSON(jsn string) (*Nonce, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(fmt.Sprintf(`"%s"`, jsn))
 	defer C.free(unsafe.Pointer(cjson))
@@ -46,8 +42,31 @@ func NonceFromJson(jsn string) (unsafe.Pointer, error) {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return handle, nil
+	return &Nonce{handle}, nil
 }
+
+func (r *Nonce) ToJSON() ([]byte, error) {
+	var d *C.char
+	defer C.free(unsafe.Pointer(d))
+
+	result := C.ursa_cl_nonce_to_json(r.ptr, &d)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	out := []byte(C.GoString(d))
+	return out, nil
+}
+
+func (r *Nonce) Free() error {
+	result := C.ursa_cl_nonce_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
 // BlindedCredentialSecretsCorrectnessProofFromJSON creates and returns blinded credential secrets correctness proof json.
 func BlindedCredentialSecretsCorrectnessProofFromJSON(jsn string) (unsafe.Pointer, error) {
 	var handle unsafe.Pointer
@@ -61,7 +80,6 @@ func BlindedCredentialSecretsCorrectnessProofFromJSON(jsn string) (unsafe.Pointe
 
 	return handle, nil
 }
-
 
 //CredentialKeyCorrectnessProofFromJSON creates and returns credential key correctness proof from json
 func CredentialKeyCorrectnessProofFromJSON(jsn string) (unsafe.Pointer, error) {
@@ -119,8 +137,11 @@ func CredentialPublicKeyFromJSON(jsn string) (unsafe.Pointer, error) {
 	return handle, nil
 }
 
+type NonCredentialSchemaBuilder Handle
+type NonCredentialSchemaHandle Handle
+
 //NonCredentialSchemaBuilderNew creates and returns non credential schema builder
-func NonCredentialSchemaBuilderNew() (unsafe.Pointer, error) {
+func NewNonCredentialSchemaBuilder() (*NonCredentialSchemaBuilder, error) {
 	var nonBuilder unsafe.Pointer
 
 	result := C.ursa_cl_non_credential_schema_builder_new(&nonBuilder)
@@ -128,15 +149,15 @@ func NonCredentialSchemaBuilderNew() (unsafe.Pointer, error) {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return nonBuilder, nil
+	return &NonCredentialSchemaBuilder{nonBuilder}, nil
 }
 
 //NonCredentialSchemaBuilderAddAttr adds new attribute to non credential schema
-func NonCredentialSchemaBuilderAddAttr(nonBuilder unsafe.Pointer, attr string) error {
+func (r *NonCredentialSchemaBuilder) AddAttr(attr string) error {
 	cAttr := C.CString(attr)
 	defer C.free(unsafe.Pointer(cAttr))
 
-	result := C.ursa_cl_non_credential_schema_builder_add_attr(nonBuilder, cAttr)
+	result := C.ursa_cl_non_credential_schema_builder_add_attr(r.ptr, cAttr)
 	if result.code != 0 {
 		return ursaError(C.GoString(result.message))
 	}
@@ -145,32 +166,45 @@ func NonCredentialSchemaBuilderAddAttr(nonBuilder unsafe.Pointer, attr string) e
 }
 
 //NonCredentialSchemaBuilderFinalize deallocates non_credential schema builder and returns non credential schema entity instead
-func NonCredentialSchemaBuilderFinalize(nonBuilder unsafe.Pointer) (unsafe.Pointer, error) {
+func (r *NonCredentialSchemaBuilder) Finalize() (*NonCredentialSchemaHandle, error) {
 	var nonSchema unsafe.Pointer
 
-	result := C.ursa_cl_non_credential_schema_builder_finalize(nonBuilder, &nonSchema)
+	result := C.ursa_cl_non_credential_schema_builder_finalize(r.ptr, &nonSchema)
 	if result.code != 0 {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return nonSchema, nil
+	return &NonCredentialSchemaHandle{nonSchema}, nil
 }
 
+//FreeNonCredentialSchema deallocates credential schema instance
+func (r *NonCredentialSchemaHandle) Free() error {
+	result := C.ursa_cl_non_credential_schema_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+type CredentialSchemaBuilder Handle
+type CredentialSchemaHandle Handle
+
 //CredentialSchemaBuilderNew creates and return credential schema entity builder
-func CredentialSchemaBuilderNew() (unsafe.Pointer, error) {
+func NewCredentialSchemaBuilder() (*CredentialSchemaBuilder, error) {
 	var builder unsafe.Pointer
 	result := C.ursa_cl_credential_schema_builder_new(&builder)
 	if result.code != 0 {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return builder, nil
+	return &CredentialSchemaBuilder{builder}, nil
 }
 
 //CredentialSchemaBuilderAddAttr adds new attribute to credential schema
-func CredentialSchemaBuilderAddAttr(builder unsafe.Pointer, field string) error {
+func (r *CredentialSchemaBuilder) AddAttr(field string) error {
 	cfield := C.CString(field)
-	result := C.ursa_cl_credential_schema_builder_add_attr(builder, cfield)
+	result := C.ursa_cl_credential_schema_builder_add_attr(r.ptr, cfield)
 	C.free(unsafe.Pointer(cfield))
 	if result.code != 0 {
 		return ursaError(C.GoString(result.message))
@@ -180,92 +214,116 @@ func CredentialSchemaBuilderAddAttr(builder unsafe.Pointer, field string) error 
 }
 
 //CredentialSchemaBuilderFinalize deallocates credential schema builder and return credential schema entity instead
-func CredentialSchemaBuilderFinalize(builder unsafe.Pointer) (unsafe.Pointer, error) {
+func (r *CredentialSchemaBuilder) Finalize() (*CredentialSchemaHandle, error) {
 	var schema unsafe.Pointer
 
-	result := C.ursa_cl_credential_schema_builder_finalize(builder, &schema)
+	result := C.ursa_cl_credential_schema_builder_finalize(r.ptr, &schema)
 	if result.code != 0 {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
-	return schema, nil
+	return &CredentialSchemaHandle{schema}, nil
+}
+
+//Free deallocates credential schema instance
+func (r *CredentialSchemaHandle) Free() error {
+	result := C.ursa_cl_credential_schema_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+type CredentialDefPubKey Handle
+type CredentialDefPrivKey Handle
+type CredentialDefKeyCorrectnessProof Handle
+
+func (r *CredentialDefPubKey) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_credential_public_key_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *CredentialDefPubKey) Free() error {
+	result := C.ursa_cl_credential_public_key_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *CredentialDefPrivKey) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_credential_private_key_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *CredentialDefPrivKey) Free() error {
+	result := C.ursa_cl_credential_private_key_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *CredentialDefKeyCorrectnessProof) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_credential_key_correctness_proof_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *CredentialDefKeyCorrectnessProof) Free() error {
+	result := C.ursa_cl_credential_key_correctness_proof_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
 }
 
 type CredentialDef struct {
-	PubKey unsafe.Pointer
-	PrivKey unsafe.Pointer
-	KeyCorrectnessProof unsafe.Pointer
+	PubKey              *CredentialDefPubKey
+	PrivKey             *CredentialDefPrivKey
+	KeyCorrectnessProof *CredentialDefKeyCorrectnessProof
 }
 
 //NewCredentialDef creates and returns credential definition (public and private keys, correctness proof) entities
-func NewCredentialDef(schema, nonSchema unsafe.Pointer, revocation bool) (*CredentialDef, error) {
-	rev := C.bool(revocation)
-	defer C.free(unsafe.Pointer(&rev))
-
+func NewCredentialDef(schema *CredentialSchemaHandle, nonSchema *NonCredentialSchemaHandle, revocation bool) (*CredentialDef, error) {
 	var credpub, credpriv, credproof unsafe.Pointer
 
-	result := C.ursa_cl_issuer_new_credential_def(schema, nonSchema, rev, &credpub, &credpriv, &credproof)
+	result := C.ursa_cl_issuer_new_credential_def(schema.ptr, nonSchema.ptr, C.bool(revocation), &credpub, &credpriv, &credproof)
 	if result.code != 0 {
 		return nil, ursaError(C.GoString(result.message))
 	}
 
 	credDef := &CredentialDef{
-		PubKey: credpub,
-		PrivKey: credpriv,
-		KeyCorrectnessProof: credproof,
+		PubKey:              &CredentialDefPubKey{credpub},
+		PrivKey:             &CredentialDefPrivKey{credpriv},
+		KeyCorrectnessProof: &CredentialDefKeyCorrectnessProof{credproof},
 	}
 
 	return credDef, nil
-}
-
-//FreeCredentialSchema deallocates credential schema instance
-func FreeCredentialSchema(schema unsafe.Pointer) error {
-	result := C.ursa_cl_credential_schema_free(schema)
-	if result.code != 0 {
-		return ursaError(C.GoString(result.message))
-	}
-
-	return nil
-}
-
-//FreeNonCredentialSchema deallocates credential schema instance
-func FreeNonCredentialSchema(nonSchema unsafe.Pointer) error {
-	result := C.ursa_cl_non_credential_schema_free(nonSchema)
-	if result.code != 0 {
-		return ursaError(C.GoString(result.message))
-	}
-
-	return nil
-}
-
-//FreeCredentialPrivateKey deallocates credential private key instance
-func FreeCredentialPrivateKey(privKey unsafe.Pointer) error {
-	result := C.ursa_cl_credential_private_key_free(privKey)
-	if result.code != 0 {
-		return ursaError(C.GoString(result.message))
-	}
-
-	return nil
-}
-
-//FreeCredentialPublicKey deallocates credential public key instance
-func FreeCredentialPublicKey(pubKey unsafe.Pointer) error {
-	result := C.ursa_cl_credential_public_key_free(pubKey)
-	if result.code != 0 {
-		return ursaError(C.GoString(result.message))
-	}
-
-	return nil
-}
-
-//FreeCredentialKeyCorrectnessProof deallocates credential key correctness proof instance
-func FreeCredentialKeyCorrectnessProof(proof unsafe.Pointer) error {
-	result := C.ursa_cl_credential_key_correctness_proof_free(proof)
-	if result.code != 0 {
-		return ursaError(C.GoString(result.message))
-	}
-
-	return nil
 }
 
 func CorrectnessProofToJSON(credSignatureCorrectnessProof unsafe.Pointer) ([]byte, error) {
@@ -281,14 +339,14 @@ func CorrectnessProofToJSON(credSignatureCorrectnessProof unsafe.Pointer) ([]byt
 }
 
 type SignatureParams struct {
-	ProverID string
-	BlindedCredentialSecrets string
-	BlindedCredentialSecretsCorrectnessProof string
-	CredentialIssuanceNonce string
-	CredentialNonce string
-	CredentialValues unsafe.Pointer
-	CredentialPubKey string
-	CredentialPrivKey string
+	ProverID                                 string
+	BlindedCredentialSecrets                 *BlindedCredentialSecretsHandle
+	BlindedCredentialSecretsCorrectnessProof *BlindedCredentialSecretsCorrectnessProof
+	CredentialIssuanceNonce                  *Nonce
+	CredentialNonce                          *Nonce
+	CredentialValues                         *CredentialValues
+	CredentialPubKey                         *CredentialDefPubKey
+	CredentialPrivKey                        *CredentialDefPrivKey
 }
 
 //NewSignatureParams creates an empty instance of SignatureParams
@@ -296,64 +354,197 @@ func NewSignatureParams() *SignatureParams {
 	return &SignatureParams{}
 }
 
+type CredentialSignature Handle
+type CredentialSignatureCorrectnessProof Handle
+
+func CredentialSignatureFromJSON(jsn []byte) (*CredentialSignature, error) {
+	var handle unsafe.Pointer
+	cjson := C.CString(string(jsn))
+	defer C.free(unsafe.Pointer(cjson))
+
+	result := C.ursa_cl_credential_signature_from_json(cjson, &handle)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &CredentialSignature{handle}, nil
+}
+
+func CredentialSignatureCorrectnessProofFromJSON(jsn []byte) (*CredentialSignatureCorrectnessProof, error) {
+	var handle unsafe.Pointer
+	cjson := C.CString(string(jsn))
+	defer C.free(unsafe.Pointer(cjson))
+
+	result := C.ursa_cl_signature_correctness_proof_from_json(cjson, &handle)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &CredentialSignatureCorrectnessProof{handle}, nil
+}
+
 //SignCredential signs credential values with primary keys only
-func (r *SignatureParams) SignCredential() ([]byte, error) {
-	defer C.free(r.CredentialValues)
+func (r *SignatureParams) SignCredential() (*CredentialSignature, *CredentialSignatureCorrectnessProof, error) {
 	var credSignature, credSignatureCorrectnessProof unsafe.Pointer
 
 	did := C.CString(r.ProverID)
 
-	blindedCredentialSecrets, err := BlindedCredentialSecretsFromJSON(r.BlindedCredentialSecrets)
-	if err != nil {
-		return nil, err
+	result := C.ursa_cl_issuer_sign_credential(
+		did,
+		r.BlindedCredentialSecrets.ptr,
+		r.BlindedCredentialSecretsCorrectnessProof.ptr,
+		r.CredentialNonce.ptr,
+		r.CredentialIssuanceNonce.ptr,
+		r.CredentialValues.ptr,
+		r.CredentialPubKey.ptr,
+		r.CredentialPrivKey.ptr,
+		&credSignature,
+		&credSignatureCorrectnessProof)
+	if result.code != 0 {
+		return nil, nil, ursaError(C.GoString(result.message))
 	}
 
-	blindedCredentialSecretsCorrectnessProof, err := BlindedCredentialSecretsCorrectnessProofFromJSON(r.BlindedCredentialSecretsCorrectnessProof)
-	if err != nil {
-		return nil, err
+	return &CredentialSignature{credSignature}, &CredentialSignatureCorrectnessProof{credSignatureCorrectnessProof}, nil
+}
+
+func (r *CredentialSignature) Free() error {
+	result := C.ursa_cl_credential_signature_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
 	}
 
-	credentialIssuanceNonce, err := NonceFromJson(r.CredentialIssuanceNonce)
-	if err != nil {
-		return nil, err
-	}
+	return nil
+}
 
-	credentialNonce, err := NonceFromJson(r.CredentialNonce)
-	if err != nil {
-		return nil, err
-	}
+func (r *CredentialSignature) ToJSON() ([]byte, error) {
+	var jsn *C.char
 
-	credentialPubKey, err := CredentialPublicKeyFromJSON(r.CredentialPubKey)
-	if err != nil {
-		return nil, err
-	}
-
-	credentialPrivKey, err := CredentialPrivateKeyFromJSON(r.CredentialPrivKey)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		C.free(unsafe.Pointer(did))
-		C.free(blindedCredentialSecrets)
-		C.free(blindedCredentialSecretsCorrectnessProof)
-		C.free(credentialIssuanceNonce)
-		C.free(credentialNonce)
-		C.free(credentialPubKey)
-		C.free(credentialPrivKey)
-	}()
-
-	result := C.ursa_cl_issuer_sign_credential(did, blindedCredentialSecrets, blindedCredentialSecretsCorrectnessProof,
-		credentialIssuanceNonce, credentialNonce, r.CredentialValues, credentialPubKey, credentialPrivKey, &credSignature, &credSignatureCorrectnessProof)
+	result := C.ursa_cl_credential_signature_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
 	if result.code != 0 {
 		return nil, ursaError(C.GoString(result.message))
 	}
-	var sigOut *C.char
-	result = C.ursa_cl_credential_signature_to_json(credSignature, &sigOut)
-	defer C.free(unsafe.Pointer(sigOut))
-	defer C.ursa_cl_credential_signature_free(credSignature)
 
-	return []byte(C.GoString(sigOut)), nil
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *CredentialSignatureCorrectnessProof) Free() error {
+	result := C.ursa_cl_signature_correctness_proof_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *CredentialSignatureCorrectnessProof) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_signature_correctness_proof_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+type BlindedCredentialSecretsHandle Handle
+type CredentialSecretsBlindingFactors Handle
+type BlindedCredentialSecretsCorrectnessProof Handle
+
+func (r *BlindedCredentialSecretsHandle) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_blinded_credential_secrets_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *BlindedCredentialSecretsHandle) Free() error {
+	result := C.ursa_cl_blinded_credential_secrets_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *CredentialSecretsBlindingFactors) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_credential_secrets_blinding_factors_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *CredentialSecretsBlindingFactors) Free() error {
+	result := C.ursa_cl_credential_secrets_blinding_factors_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+func (r *BlindedCredentialSecretsCorrectnessProof) ToJSON() ([]byte, error) {
+	var jsn *C.char
+
+	result := C.ursa_cl_blinded_credential_secrets_correctness_proof_to_json(r.ptr, &jsn)
+	defer C.free(unsafe.Pointer(jsn))
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return []byte(C.GoString(jsn)), nil
+}
+
+func (r *BlindedCredentialSecretsCorrectnessProof) Free() error {
+	result := C.ursa_cl_blinded_credential_secrets_correctness_proof_free(r.ptr)
+	if result.code != 0 {
+		return ursaError(C.GoString(result.message))
+	}
+
+	return nil
+}
+
+type BlindedCredentialSecrets struct {
+	Handle           *BlindedCredentialSecretsHandle
+	BlindingFactor   *CredentialSecretsBlindingFactors
+	CorrectnessProof *BlindedCredentialSecretsCorrectnessProof
+}
+
+func BlindCredentialSecrets(credentialPubKey *CredentialDefPubKey, keyCorrectnessProof *CredentialDefKeyCorrectnessProof, nonce *Nonce,
+	values *CredentialValues) (*BlindedCredentialSecrets, error) {
+
+	var blindedCredentialSecrets, blindedCredentialSecretsCorrectnessProof, credentialSecretsBlindingFactors unsafe.Pointer
+
+	result := C.ursa_cl_prover_blind_credential_secrets(
+		credentialPubKey.ptr,
+		keyCorrectnessProof.ptr,
+		values.ptr,
+		nonce.ptr,
+		&blindedCredentialSecrets,
+		&credentialSecretsBlindingFactors,
+		&blindedCredentialSecretsCorrectnessProof)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &BlindedCredentialSecrets{
+		Handle:           &BlindedCredentialSecretsHandle{blindedCredentialSecrets},
+		BlindingFactor:   &CredentialSecretsBlindingFactors{credentialSecretsBlindingFactors},
+		CorrectnessProof: &BlindedCredentialSecretsCorrectnessProof{blindedCredentialSecretsCorrectnessProof},
+	}, nil
+
 }
 
 func ursaError(msg string) error {

--- a/pkg/libursa/ursa/ursa_cl.h
+++ b/pkg/libursa/ursa/ursa_cl.h
@@ -76,7 +76,7 @@ struct ExternError ursa_cl_nonce_to_json(void* nonce, const char** nonce_json_p)
  * # Arguments
  * * `nonce` - Reference that contains nonce instance pointer.
  */
-ErrorCode ursa_cl_nonce_free(const void *nonce);
+struct ExternError ursa_cl_nonce_free(const void *nonce);
 
 
 /**
@@ -141,6 +141,15 @@ struct ExternError ursa_cl_blinded_credential_secrets_from_json(const char *blin
 */
 struct ExternError ursa_cl_credential_private_key_from_json(const char *credential_priv_key_json,
                                                   const void **credential_priv_key_p);
+/**
+ * Returns json representation of credential private key.
+ *
+ * # Arguments
+ * * `credential_priv_key` - Reference that contains credential private key instance pointer.
+ * * `credential_pub_key_p` - Reference that will contain credential private key json.
+ */
+struct ExternError ursa_cl_credential_private_key_to_json(const void *credential_priv_key,
+                                                 const char **credential_priv_key_json_p);
 
 /**
  * Creates and returns credential public key from json.
@@ -155,6 +164,16 @@ struct ExternError ursa_cl_credential_private_key_from_json(const char *credenti
 struct ExternError ursa_cl_credential_public_key_from_json(const char *credential_pub_key_json,
                                                   const void **credential_pub_key_p);
 /**
+ * Returns json representation of credential public key.
+ *
+ * # Arguments
+ * * `credential_pub_key` - Reference that contains credential public key instance pointer.
+ * * `credential_pub_key_p` - Reference that will contain credential public key json.
+ */
+struct ExternError ursa_cl_credential_public_key_to_json(const void *credential_pub_key,
+                                                const char **credential_pub_key_json_p);
+
+/**
  * Returns json representation of credential signature.
  *
  * # Arguments
@@ -163,6 +182,28 @@ struct ExternError ursa_cl_credential_public_key_from_json(const char *credentia
  */
 struct ExternError ursa_cl_credential_signature_to_json(const void *credential_signature,
                                                const char **credential_signature_json_p);
+
+
+/**
+ * Creates and returns credential signature from json.
+ *
+ * Note: Credential signature instance deallocation must be performed
+ * by calling ursa_cl_credential_signature_free
+ *
+ * # Arguments
+ * * `credential_signature_json` - Reference that contains credential signature json.
+ * * `credential_signature_p` - Reference that will contain credential signature instance pointer.
+ */
+struct ExternError ursa_cl_credential_signature_from_json(const char *credential_signature_json,
+                                                 const void **credential_signature_p);
+
+/**
+ * Deallocates credential signature signature instance.
+ *
+ * # Arguments
+ * * `credential_signature` - Reference that contains credential signature instance pointer.
+ */
+struct ExternError ursa_cl_credential_signature_free(const void *credential_signature);
 
 /**
  * Signs credential values with primary keys only.
@@ -204,15 +245,38 @@ struct ExternError ursa_cl_issuer_sign_credential(const char *prover_id,
  * * `signature_correctness_proof_json_p` - Reference that will contain signature correctness proof json.
  */
 struct ExternError ursa_cl_signature_correctness_proof_to_json(const void *signature_correctness_proof,
-                                                      const char **signature_correctness_proof_json_p);
+                                                               const char **signature_correctness_proof_json_p);
 
 /**
- * Deallocates credential signature signature instance.
+ * Creates and returns signature correctness proof from json.
+ *
+ * Note: Signature correctness proof instance deallocation must be performed
+ * by calling ursa_cl_signature_correctness_proof_free
  *
  * # Arguments
- * * `credential_signature` - Reference that contains credential signature instance pointer.
+ * * `signature_correctness_proof_json` - Reference that contains signature correctness proof json.
+ * * `signature_correctness_proof_p` - Reference that will contain signature correctness proof instance pointer.
  */
-struct ExternError ursa_cl_credential_signature_free(const void *credential_signature);
+struct ExternError ursa_cl_signature_correctness_proof_from_json(const char *signature_correctness_proof_json,
+                                                                 const void **signature_correctness_proof_p);
+
+/**
+ * Deallocates signature correctness proof instance.
+ *
+ * # Arguments
+ * * `signature_correctness_proof` - Reference that contains signature correctness proof instance pointer.
+ */
+struct ExternError ursa_cl_signature_correctness_proof_free(const void *signature_correctness_proof);
+
+
+
+/**
+ * Deallocates blinded credential secrets correctness proof instance.
+ *
+ * # Arguments
+ * * `blinded_credential_secrets_correctness_proof` - Reference that contains blinded credential secrets correctness proof instance pointer.
+ */
+struct ExternError ursa_cl_blinded_credential_secrets_correctness_proof_free(const void *blinded_credential_secrets_correctness_proof);
 
 /**
  * Adds new attribute to non credential schema.
@@ -427,3 +491,305 @@ struct ExternError ursa_cl_credential_private_key_free(const void *credential_pr
  * * `credential_pub_key` - Reference that contains credential public key instance pointer.
  */
 struct ExternError ursa_cl_credential_public_key_free(const void *credential_pub_key);
+
+/**
+ * Creates and returns proof builder.
+ *
+ * The purpose of proof builder is building of proof entity according to the given request .
+ *
+ * Note that proof builder deallocation must be performed by
+ * calling ursa_cl_proof_builder_finalize.
+ *
+ * # Arguments
+ * * `proof_builder_p` - Reference that will contain proof builder instance pointer.
+ */
+struct ExternError ursa_cl_prover_new_proof_builder(const void **proof_builder_p);
+
+
+
+/**
+ * Add a common attribute to the proof builder
+ *
+ * # Arguments
+ * * `proof_builder` - Reference that contain proof builder instance pointer.
+ * * `attribute_name` - Common attribute's name
+ */
+struct ExternError ursa_cl_proof_builder_add_common_attribute(const void *proof_builder,
+                                                     const char *attribute_name);
+
+/**
+ * Add a sub proof request to the proof builder
+ *
+ * # Arguments
+ * * `proof_builder` - Reference that contain proof builder instance pointer.
+ * * `sub_proof_request` - Reference that contain sub proof request instance pointer.
+ * * `credential_schema` - Reference that contains credential schema instance pointer.
+ * * `non_credential_schema` - Reference that contains non credential schema instance pointer.
+ * * `credential_signature` - Reference that contains the credential signature pointer.
+ * * `credential_values` - Reference that contains credential values instance pointer.
+ * * `credential_pub_key` - Reference that contains credential public key instance pointer.
+ * * `rev_reg` - (Optional) Reference that will contain revocation registry public instance pointer.
+ * * `witness` - (Optional) Reference that will contain witness instance pointer.
+ */
+struct ExternError ursa_cl_proof_builder_add_sub_proof_request(const void *proof_builder,
+                                                      const void *sub_proof_request,
+                                                      const void *credential_schema,
+                                                      const void *non_credential_schema,
+                                                      const void *credential_signature,
+                                                      const void *credential_values,
+                                                      const void *credential_pub_key,
+                                                      const void *rev_reg,
+                                                      const void *witness);
+
+/**
+ * Finalize proof.
+ *
+ * Note that proof deallocation must be performed by
+ * calling ursa_cl_proof_free.
+ *
+ * # Arguments
+ * * `proof_builder` - Reference that contain proof builder instance pointer.
+ * * `nonce` - Reference that contain nonce instance pointer.
+ * * `proof_p` - Reference that will contain proof instance pointer.
+ */
+struct ExternError ursa_cl_proof_builder_finalize(const void *proof_builder,
+                                         const void *nonce,
+                                         const void **proof_p);
+
+/**
+ * Deallocates proof instance.
+ *
+ * # Arguments
+ * * `proof` - Reference that contains proof instance pointer.
+ */
+struct ExternError ursa_cl_proof_free(const void *proof);
+
+/**
+ * Creates and returns proof json.
+ *
+ * Note: Proof instance deallocation must be performed by calling ursa_cl_proof_free.
+ *
+ * # Arguments
+ * * `proof_json` - Reference that contains proof json.
+ * * `proof_p` - Reference that will contain proof instance pointer.
+ */
+struct ExternError ursa_cl_proof_from_json(const char *proof_json, const void **proof_p);
+
+/**
+ * Returns json representation of proof.
+ *
+ * # Arguments
+ * * `proof` - Reference that contains proof instance pointer.
+ * * `proof_json_p` - Reference that will contain proof json.
+ */
+struct ExternError ursa_cl_proof_to_json(const void *proof, const char **proof_json_p);
+
+/**
+ * Creates and returns sub proof request entity builder.
+ *
+ * The purpose of sub proof request builder is building of sub proof request entity that
+ * represents requested attributes and predicates.
+ *
+ * Note: sub proof request builder instance deallocation must be performed by
+ * calling ursa_cl_sub_proof_request_builder_finalize.
+ *
+ * # Arguments
+ * * `sub_proof_request_builder_p` - Reference that will contain sub proof request builder instance pointer.
+ */
+struct ExternError ursa_cl_sub_proof_request_builder_new(const void **sub_proof_request_builder_p);
+
+/**
+ * Adds predicate to sub proof request.
+ *
+ * # Arguments
+ * * `sub_proof_request_builder` - Reference that contains sub proof request builder instance pointer.
+ * * `attr_name` - Related attribute
+ * * `p_type` - Predicate type (Currently `GE` only).
+ * * `value` - Requested value.
+ */
+struct ExternError ursa_cl_sub_proof_request_builder_add_predicate(const void *sub_proof_request_builder,
+                                                          const char *attr_name,
+                                                          const char *p_type,
+                                                          int32_t value);
+
+/**
+ * Adds new revealed attribute to sub proof request.
+ *
+ * # Arguments
+ * * `sub_proof_request_builder` - Reference that contains sub proof request builder instance pointer.
+ * * `attr` - Credential attr to add as null terminated string.
+ */
+struct ExternError ursa_cl_sub_proof_request_builder_add_revealed_attr(const void *sub_proof_request_builder,
+                                                              const char *attr);
+
+/**
+ * Deallocates sub proof request builder and returns sub proof request entity instead.
+ *
+ * Note: Sub proof request instance deallocation must be performed by
+ * calling ursa_cl_sub_proof_request_free.
+ *
+ * # Arguments
+ * * `sub_proof_request_builder` - Reference that contains sub proof request builder instance pointer.
+ * * `sub_proof_request_p` - Reference that will contain sub proof request instance pointer.
+ */
+struct ExternError ursa_cl_sub_proof_request_builder_finalize(const void *sub_proof_request_builder,
+                                                     const void **sub_proof_request_p);
+
+/**
+ * Deallocates sub proof request instance.
+ *
+ * # Arguments
+ * * `sub_proof_request` - Reference that contains sub proof request instance pointer.
+ */
+struct ExternError ursa_cl_sub_proof_request_free(const void *sub_proof_request);
+
+/**
+ * Returns json representation of credential key correctness proof.
+ *
+ * # Arguments
+ * * `credential_key_correctness_proof` - Reference that contains credential key correctness proof instance pointer.
+ * * `credential_key_correctness_proof_p` - Reference that will contain credential key correctness proof json.
+ */
+struct ExternError ursa_cl_credential_key_correctness_proof_to_json(const void *credential_key_correctness_proof,
+                                                           const char **credential_key_correctness_proof_json_p);
+
+/**
+ * Creates blinded credential secrets for given issuer key and master secret.
+ *
+ * Note that blinded credential secrets deallocation must be performed by
+ * calling ursa_cl_blinded_credential_secrets_free.
+ *
+ * Note that credential secrets blinding factors deallocation must be performed by
+ * calling ursa_cl_credential_secrets_blinding_factors_free.
+ *
+ * Note that blinded credential secrets correctness proof deallocation must be performed by
+ * calling ursa_cl_blinded_credential_secrets_correctness_proof_free.
+ *
+ * # Arguments
+ * * `credential_pub_key` - Reference that contains credential public key instance pointer.
+ * * `credential_key_correctness_proof` - Reference that contains credential key correctness proof instance pointer.
+ * * `credential_values` - Reference that contains credential values pointer.
+ * * `credential_nonce` - Reference that contains nonce instance pointer.
+ * * `blinded_credential_secrets_p` - Reference that will contain blinded credential secrets instance pointer.
+ * * `credential_secrets_blinding_factors_p` - Reference that will contain credential secrets blinding factors instance pointer.
+ * * `blinded_credential_secrets_correctness_proof_p` - Reference that will contain blinded credential secrets correctness proof instance pointer.
+ */
+struct ExternError ursa_cl_prover_blind_credential_secrets(const void *credential_pub_key,
+                                                           const void *credential_key_correctness_proof,
+                                                           const void *credential_values,
+                                                           const void *credential_nonce,
+                                                           const void **blinded_credential_secrets_p,
+                                                           const void **credential_secrets_blinding_factors_p,
+                                                           const void **blinded_credential_secrets_correctness_proof_p);
+
+/**
+ * Returns json representation of blinded credential secrets correctness proof.
+ *
+ * # Arguments
+ * * `blinded_credential_secrets_correctness_proof` - Reference that contains blinded credential secrets correctness proof pointer.
+ * * `blinded_credential_secrets_correctness_proof_json_p` - Reference that will contain blinded credential secrets correctness proof json.
+ */
+struct ExternError ursa_cl_blinded_credential_secrets_correctness_proof_to_json(const void *blinded_credential_secrets_correctness_proof,
+                                                                       const char **blinded_credential_secrets_correctness_proof_json_p);
+
+/**
+ * Deallocates blinded credential secrets correctness proof instance.
+ *
+ * # Arguments
+ * * `blinded_credential_secrets_correctness_proof` - Reference that contains blinded credential secrets correctness proof instance pointer.
+ */
+struct ExternError ursa_cl_blinded_credential_secrets_correctness_proof_free(const void *blinded_credential_secrets_correctness_proof);
+
+
+/**
+ * Deallocates credential secrets blinding factors instance.
+ *
+ * # Arguments
+ * * `credential_secrets_blinding_factors` - Reference that contains credential secrets blinding factors instance pointer.
+ */
+struct ExternError ursa_cl_credential_secrets_blinding_factors_free(const void *credential_secrets_blinding_factors);
+
+/**
+ * Creates and returns credential secrets blinding factors json.
+ *
+ * Note: Credential secrets blinding factors instance deallocation must be performed
+ * by calling ursa_cl_credential_secrets_blinding_factors_free.
+ *
+ * # Arguments
+ * * `credential_secrets_blinding_factors_json` - Reference that contains credential secrets blinding factors json.
+ * * `credential_secrets_blinding_factors_p` - Reference that will contain credential secrets blinding factors instance pointer.
+ */
+struct ExternErrorrrorCode ursa_cl_credential_secrets_blinding_factors_from_json(const char *credential_secrets_blinding_factors_json,
+                                                                const void **credential_secrets_blinding_factors_p);
+
+/**
+ * Returns json representation of credential secrets blinding factors.
+ *
+ * # Arguments
+ * * `credential_secrets_blinding_factors` - Reference that contains credential secrets blinding factors pointer.
+ * * `credential_secrets_blinding_factors_json_p` - Reference that will contain credential secrets blinding factors json.
+ */
+struct ExternError ursa_cl_credential_secrets_blinding_factors_to_json(const void *credential_secrets_blinding_factors,
+                                                              const char **credential_secrets_blinding_factors_json_p);
+
+
+/**
+ * Returns json representation of blinded credential secrets.
+ *
+ * # Arguments
+ * * `blinded_credential_secrets` - Reference that contains Blinded credential secrets pointer.
+ * * `blinded_credential_secrets_json_p` - Reference that will contain blinded credential secrets json.
+ */
+struct ExternError ursa_cl_blinded_credential_secrets_to_json(const void *blinded_credential_secrets,
+                                                     const char **blinded_credential_secrets_json_p);
+
+/**
+ * Deallocates  blinded credential secrets instance.
+ *
+ * # Arguments
+ * * `blinded_credential_secrets` - Reference that contains blinded credential secrets instance pointer.
+ */
+struct ExternError ursa_cl_blinded_credential_secrets_free(const void *blinded_credential_secrets);
+
+/**
+ * Creates a master secret.
+ *
+ * Note that master secret deallocation must be performed by
+ * calling ursa_cl_master_secret_free.
+ *
+ * # Arguments
+ * * `master_secret_p` - Reference that will contain master secret instance pointer.
+ */
+struct ExternError ursa_cl_prover_new_master_secret(const void **master_secret_p);
+
+/**
+ * Deallocates master secret instance.
+ *
+ * # Arguments
+ * * `master_secret` - Reference that contains master secret instance pointer.
+ */
+struct ExternError ursa_cl_master_secret_free(const void *master_secret);
+
+/**
+ * Creates and returns master secret from json.
+ *
+ * Note: Master secret instance deallocation must be performed
+ * by calling ursa_cl_master_secret_free.
+ *
+ * # Arguments
+ * * `master_secret_json` - Reference that contains master secret json.
+ * * `master_secret_p` - Reference that will contain master secret instance pointer.
+ */
+struct ExternError ursa_cl_master_secret_from_json(const char *master_secret_json,
+                                          const void **master_secret_p);
+
+/**
+ * Returns json representation of master secret.
+ *
+ * # Arguments
+ * * `master_secret` - Reference that contains master secret instance pointer.
+ * * `master_secret_json_p` - Reference that will contain master secret json.
+ */
+struct ExternError ursa_cl_master_secret_to_json(const void *master_secret,
+                                        const char **master_secret_json_p);
+

--- a/pkg/libursa/ursa/value_builder_test.go
+++ b/pkg/libursa/ursa/value_builder_test.go
@@ -2,7 +2,6 @@ package ursa
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -19,14 +18,14 @@ func TestAddDecHidden(t *testing.T) {
 	t.Run("AddDecHidden", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecHidden(builder, "master_secret", "122345")
+		err := builder.AddDecHidden("master_secret", "122345")
 		assert.Empty(t, err)
 	})
 
 	t.Run("AddDecHidden", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecHidden(builder, "master_secret", "fail")
+		err := builder.AddDecHidden("master_secret", "fail")
 		assert.NotEmpty(t, err)
 	})
 }
@@ -35,14 +34,14 @@ func TestAddDecKnown(t *testing.T) {
 	t.Run("AddDecKnown", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecKnown(builder, "master_secret", "12a2345")
+		err := builder.AddDecKnown("master_secret", "12a2345")
 		assert.Empty(t, err)
 	})
 
 	t.Run("AddDecKnown", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecKnown(builder, "master_secret", "fail")
+		err := builder.AddDecKnown("master_secret", "fail")
 		assert.NotEmpty(t, err)
 	})
 }
@@ -51,14 +50,14 @@ func TestAddDecCommitment(t *testing.T) {
 	t.Run("AddDecCommitment", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecCommitment(builder, "master_secret", "12345", "9876")
+		err := builder.AddDecCommitment("master_secret", "12345", "9876")
 		assert.Empty(t, err)
 	})
 
 	t.Run("AddDecCommitment", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		err := AddDecCommitment(builder, "master_secret", "fail", "9876")
+		err := builder.AddDecCommitment("master_secret", "fail", "9876")
 		assert.NotEmpty(t, err)
 	})
 }
@@ -67,17 +66,8 @@ func TestFinalizeBuilder(t *testing.T) {
 	t.Run("FinalizeBuilder", func(t *testing.T) {
 		builder, _ := NewValueBuilder()
 
-		values, err := FinalizeBuilder(builder)
+		values, err := builder.Finalize()
 		assert.Empty(t, err)
 		assert.NotEmpty(t, values)
-	})
-}
-
-func TestFreeCredentialValues(t *testing.T) {
-	t.Run("FreeCredentialValues", func(t *testing.T) {
-		var values unsafe.Pointer
-
-		err := FreeCredentialValues(values)
-		assert.NotEmpty(t, err)
 	})
 }


### PR DESCRIPTION
This PR includes:

- Wrapper for signing credentials
- Wrapper for generating proofs
- Refactor of some existing methods to match a pattern to encapsulate the `unsafe.Pointer` handles away from callers.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>
