### PR TITLE
Final wrapped method needed to round trip Indy credentials.

### DIFF
--- a/pkg/libursa/ursa/master_secret.go
+++ b/pkg/libursa/ursa/master_secret.go
@@ -12,6 +12,7 @@ import (
 
 type MasterSecret Handle
 
+// NewMasterSecret creates a master secret
 func NewMasterSecret() (*MasterSecret, error) {
 	var ms unsafe.Pointer
 
@@ -23,7 +24,7 @@ func NewMasterSecret() (*MasterSecret, error) {
 	return &MasterSecret{ms}, nil
 }
 
-//MasterSecretFromJson creates and returns nonce json
+//MasterSecretFromJson creates and returns master secret from json
 func MasterSecretFromJSON(jsn []byte) (*MasterSecret, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -37,6 +38,7 @@ func MasterSecretFromJSON(jsn []byte) (*MasterSecret, error) {
 	return &MasterSecret{handle}, nil
 }
 
+// ToJSON returns json representation of master secret
 func (r *MasterSecret) ToJSON() ([]byte, error) {
 	var d *C.char
 	defer C.free(unsafe.Pointer(d))
@@ -50,6 +52,7 @@ func (r *MasterSecret) ToJSON() ([]byte, error) {
 	return out, nil
 }
 
+// Free deallocates master secret instance
 func (r *MasterSecret) Free() error {
 	result := C.ursa_cl_master_secret_free(r.ptr)
 	if result.code != 0 {

--- a/pkg/libursa/ursa/proof_builder.go
+++ b/pkg/libursa/ursa/proof_builder.go
@@ -13,6 +13,7 @@ import (
 type ProofBuilder Handle
 type ProofHandle Handle
 
+// NewProofBuilder
 func NewProofBuilder() (*ProofBuilder, error) {
 	var builder unsafe.Pointer
 
@@ -24,6 +25,7 @@ func NewProofBuilder() (*ProofBuilder, error) {
 	return &ProofBuilder{builder}, nil
 }
 
+// ProofFromJSON creates and returns proof from JSON
 func ProofFromJSON(jsn []byte) (*ProofHandle, error) {
 	var builder unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -37,6 +39,7 @@ func ProofFromJSON(jsn []byte) (*ProofHandle, error) {
 	return &ProofHandle{builder}, nil
 }
 
+// AddCommonAttribute add a common attribute to the proof builder
 func (r *ProofBuilder) AddCommonAttribute(attr string) error {
 	cattr := C.CString(attr)
 	defer C.free(unsafe.Pointer(cattr))
@@ -49,6 +52,7 @@ func (r *ProofBuilder) AddCommonAttribute(attr string) error {
 	return nil
 }
 
+// AddSubProofRequest add a sub proof request to the proof builder
 func (r *ProofBuilder) AddSubProofRequest(subProof *SubProofRequestHandle, credSchema *CredentialSchemaHandle,
 	nonCredSchema *NonCredentialSchemaHandle, signature *CredentialSignature, values *CredentialValues, pubKey *CredentialDefPubKey) error {
 
@@ -61,6 +65,7 @@ func (r *ProofBuilder) AddSubProofRequest(subProof *SubProofRequestHandle, credS
 	return nil
 }
 
+// Finalize finalize the proof
 func (r *ProofBuilder) Finalize(nonce *Nonce) (*ProofHandle, error) {
 	var proof unsafe.Pointer
 
@@ -72,6 +77,7 @@ func (r *ProofBuilder) Finalize(nonce *Nonce) (*ProofHandle, error) {
 	return &ProofHandle{proof}, nil
 }
 
+// ToJSON returns JSON representation of proof
 func (r *ProofHandle) ToJSON() ([]byte, error) {
 	var d *C.char
 	defer C.free(unsafe.Pointer(d))
@@ -84,6 +90,7 @@ func (r *ProofHandle) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(d)), nil
 }
 
+// Free deallocates proof instance
 func (r *ProofHandle) Free() error {
 	result := C.ursa_cl_proof_free(r.ptr)
 	if result.code != 0 {
@@ -96,6 +103,7 @@ func (r *ProofHandle) Free() error {
 type SubProofRequestBuilder Handle
 type SubProofRequestHandle Handle
 
+// NewSubProofRequestBuilder creates and returns sub proof request entity builder
 func NewSubProofRequestBuilder() (*SubProofRequestBuilder, error) {
 	var builder unsafe.Pointer
 
@@ -108,6 +116,7 @@ func NewSubProofRequestBuilder() (*SubProofRequestBuilder, error) {
 
 }
 
+// AddPredicate adds predicate to sub proof request
 func (r *SubProofRequestBuilder) AddPredicate(attr, ptype string, value int32) error {
 	cattr := C.CString(attr)
 	defer C.free(unsafe.Pointer(cattr))
@@ -122,6 +131,7 @@ func (r *SubProofRequestBuilder) AddPredicate(attr, ptype string, value int32) e
 	return nil
 }
 
+// AddRevealedAttr adds new revealed attribute to sub proof request.
 func (r *SubProofRequestBuilder) AddRevealedAttr(attr string) error {
 	cattr := C.CString(attr)
 	defer C.free(unsafe.Pointer(cattr))
@@ -134,6 +144,7 @@ func (r *SubProofRequestBuilder) AddRevealedAttr(attr string) error {
 	return nil
 }
 
+// Finalize deallocates sub proof request builder and returns sub proof request entity instead.
 func (r *SubProofRequestBuilder) Finalize() (*SubProofRequestHandle, error) {
 	var proof unsafe.Pointer
 
@@ -145,6 +156,7 @@ func (r *SubProofRequestBuilder) Finalize() (*SubProofRequestHandle, error) {
 	return &SubProofRequestHandle{proof}, nil
 }
 
+// Free deallocates sub proof request instance
 func (r *SubProofRequestHandle) Free() error {
 	result := C.ursa_cl_sub_proof_request_free(r.ptr)
 	if result.code != 0 {

--- a/pkg/libursa/ursa/ursa.go
+++ b/pkg/libursa/ursa/ursa.go
@@ -18,7 +18,7 @@ type Handle struct {
 
 type Nonce Handle
 
-//NewNonce creates a random nonce
+// NewNonce creates a random nonce
 func NewNonce() (*Nonce, error) {
 	var nonce unsafe.Pointer
 
@@ -30,7 +30,7 @@ func NewNonce() (*Nonce, error) {
 	return &Nonce{nonce}, nil
 }
 
-//NonceFromJson creates and returns nonce json
+// NonceFromJSON creates and returns nonce from json
 func NonceFromJSON(jsn string) (*Nonce, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(jsn)
@@ -44,6 +44,7 @@ func NonceFromJSON(jsn string) (*Nonce, error) {
 	return &Nonce{handle}, nil
 }
 
+// ToJSON returns JSON representation of nonce
 func (r *Nonce) ToJSON() ([]byte, error) {
 	var d *C.char
 	defer C.free(unsafe.Pointer(d))
@@ -57,6 +58,7 @@ func (r *Nonce) ToJSON() ([]byte, error) {
 	return out, nil
 }
 
+// Free deallocates the nonce
 func (r *Nonce) Free() error {
 	result := C.ursa_cl_nonce_free(r.ptr)
 	if result.code != 0 {
@@ -80,7 +82,7 @@ func BlindedCredentialSecretsCorrectnessProofFromJSON(jsn []byte) (*BlindedCrede
 	return &BlindedCredentialSecretsCorrectnessProof{handle}, nil
 }
 
-//CredentialKeyCorrectnessProofFromJSON creates and returns credential key correctness proof from json
+// CredentialKeyCorrectnessProofFromJSON creates and returns credential key correctness proof from json
 func CredentialKeyCorrectnessProofFromJSON(jsn []byte) (*CredentialDefKeyCorrectnessProof, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -94,7 +96,7 @@ func CredentialKeyCorrectnessProofFromJSON(jsn []byte) (*CredentialDefKeyCorrect
 	return &CredentialDefKeyCorrectnessProof{handle}, nil
 }
 
-//BlindedCredentialSecretsFromJSON creates and returns blinded credential secrets from json
+// BlindedCredentialSecretsFromJSON creates and returns blinded credential secrets from json
 func BlindedCredentialSecretsFromJSON(jsn []byte) (*BlindedCredentialSecretsHandle, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -108,7 +110,7 @@ func BlindedCredentialSecretsFromJSON(jsn []byte) (*BlindedCredentialSecretsHand
 	return &BlindedCredentialSecretsHandle{handle}, nil
 }
 
-//CredentialPrivateKeyFromJSON creates and returns credential private key from json
+// CredentialPrivateKeyFromJSON creates and returns credential private key from json
 func CredentialPrivateKeyFromJSON(jsn []byte) (*CredentialDefPrivKey, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -122,7 +124,7 @@ func CredentialPrivateKeyFromJSON(jsn []byte) (*CredentialDefPrivKey, error) {
 	return &CredentialDefPrivKey{handle}, nil
 }
 
-//CredentialPublicKeyFromJSON creates and returns credential public key from json
+// CredentialPublicKeyFromJSON creates and returns credential public key from json
 func CredentialPublicKeyFromJSON(jsn []byte) (*CredentialDefPubKey, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -139,7 +141,7 @@ func CredentialPublicKeyFromJSON(jsn []byte) (*CredentialDefPubKey, error) {
 type NonCredentialSchemaBuilder Handle
 type NonCredentialSchemaHandle Handle
 
-//NonCredentialSchemaBuilderNew creates and returns non credential schema builder
+// NewNonCredentialSchemaBuilder creates and returns non credential schema builder
 func NewNonCredentialSchemaBuilder() (*NonCredentialSchemaBuilder, error) {
 	var nonBuilder unsafe.Pointer
 
@@ -151,7 +153,7 @@ func NewNonCredentialSchemaBuilder() (*NonCredentialSchemaBuilder, error) {
 	return &NonCredentialSchemaBuilder{nonBuilder}, nil
 }
 
-//NonCredentialSchemaBuilderAddAttr adds new attribute to non credential schema
+// AddAttr adds new attribute to non credential schema
 func (r *NonCredentialSchemaBuilder) AddAttr(attr string) error {
 	cAttr := C.CString(attr)
 	defer C.free(unsafe.Pointer(cAttr))
@@ -164,7 +166,7 @@ func (r *NonCredentialSchemaBuilder) AddAttr(attr string) error {
 	return nil
 }
 
-//NonCredentialSchemaBuilderFinalize deallocates non_credential schema builder and returns non credential schema entity instead
+// Finalize deallocates non_credential schema builder and returns non credential schema entity instead
 func (r *NonCredentialSchemaBuilder) Finalize() (*NonCredentialSchemaHandle, error) {
 	var nonSchema unsafe.Pointer
 
@@ -176,7 +178,7 @@ func (r *NonCredentialSchemaBuilder) Finalize() (*NonCredentialSchemaHandle, err
 	return &NonCredentialSchemaHandle{nonSchema}, nil
 }
 
-//FreeNonCredentialSchema deallocates credential schema instance
+// Free deallocates credential schema instance
 func (r *NonCredentialSchemaHandle) Free() error {
 	result := C.ursa_cl_non_credential_schema_free(r.ptr)
 	if result.code != 0 {
@@ -189,7 +191,7 @@ func (r *NonCredentialSchemaHandle) Free() error {
 type CredentialSchemaBuilder Handle
 type CredentialSchemaHandle Handle
 
-//CredentialSchemaBuilderNew creates and return credential schema entity builder
+// NewCredentialSchemaBuilder creates and return credential schema entity builder
 func NewCredentialSchemaBuilder() (*CredentialSchemaBuilder, error) {
 	var builder unsafe.Pointer
 	result := C.ursa_cl_credential_schema_builder_new(&builder)
@@ -200,7 +202,7 @@ func NewCredentialSchemaBuilder() (*CredentialSchemaBuilder, error) {
 	return &CredentialSchemaBuilder{builder}, nil
 }
 
-//CredentialSchemaBuilderAddAttr adds new attribute to credential schema
+// AddAttr adds new attribute to credential schema
 func (r *CredentialSchemaBuilder) AddAttr(field string) error {
 	cfield := C.CString(field)
 	result := C.ursa_cl_credential_schema_builder_add_attr(r.ptr, cfield)
@@ -212,7 +214,7 @@ func (r *CredentialSchemaBuilder) AddAttr(field string) error {
 	return nil
 }
 
-//CredentialSchemaBuilderFinalize deallocates credential schema builder and return credential schema entity instead
+// Finalize deallocates credential schema builder and return credential schema entity instead
 func (r *CredentialSchemaBuilder) Finalize() (*CredentialSchemaHandle, error) {
 	var schema unsafe.Pointer
 
@@ -224,7 +226,7 @@ func (r *CredentialSchemaBuilder) Finalize() (*CredentialSchemaHandle, error) {
 	return &CredentialSchemaHandle{schema}, nil
 }
 
-//Free deallocates credential schema instance
+// Free deallocates credential schema instance
 func (r *CredentialSchemaHandle) Free() error {
 	result := C.ursa_cl_credential_schema_free(r.ptr)
 	if result.code != 0 {
@@ -238,6 +240,7 @@ type CredentialDefPubKey Handle
 type CredentialDefPrivKey Handle
 type CredentialDefKeyCorrectnessProof Handle
 
+// ToJSON creates and returns JSON representation of credential definition public key
 func (r *CredentialDefPubKey) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -250,6 +253,7 @@ func (r *CredentialDefPubKey) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates credential definition public key instance
 func (r *CredentialDefPubKey) Free() error {
 	result := C.ursa_cl_credential_public_key_free(r.ptr)
 	if result.code != 0 {
@@ -259,6 +263,7 @@ func (r *CredentialDefPubKey) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of credential definition private key
 func (r *CredentialDefPrivKey) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -271,6 +276,7 @@ func (r *CredentialDefPrivKey) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates credential definition private key instance
 func (r *CredentialDefPrivKey) Free() error {
 	result := C.ursa_cl_credential_private_key_free(r.ptr)
 	if result.code != 0 {
@@ -280,6 +286,7 @@ func (r *CredentialDefPrivKey) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of credential definition key correctness proof
 func (r *CredentialDefKeyCorrectnessProof) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -292,6 +299,7 @@ func (r *CredentialDefKeyCorrectnessProof) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates credential definition key correctness proof instance
 func (r *CredentialDefKeyCorrectnessProof) Free() error {
 	result := C.ursa_cl_credential_key_correctness_proof_free(r.ptr)
 	if result.code != 0 {
@@ -307,7 +315,7 @@ type CredentialDef struct {
 	KeyCorrectnessProof *CredentialDefKeyCorrectnessProof
 }
 
-//NewCredentialDef creates and returns credential definition (public and private keys, correctness proof) entities
+// NewCredentialDef creates and returns credential definition (public and private keys, correctness proof) entities
 func NewCredentialDef(schema *CredentialSchemaHandle, nonSchema *NonCredentialSchemaHandle, revocation bool) (*CredentialDef, error) {
 	var credpub, credpriv, credproof unsafe.Pointer
 
@@ -325,6 +333,7 @@ func NewCredentialDef(schema *CredentialSchemaHandle, nonSchema *NonCredentialSc
 	return credDef, nil
 }
 
+// CorrectnessProofToJSON creates and returns JSON representation of credential signature correctness proof
 func CorrectnessProofToJSON(credSignatureCorrectnessProof unsafe.Pointer) ([]byte, error) {
 	var proofOut *C.char
 
@@ -348,7 +357,7 @@ type SignatureParams struct {
 	CredentialPrivKey                        *CredentialDefPrivKey
 }
 
-//NewSignatureParams creates an empty instance of SignatureParams
+// NewSignatureParams creates an empty instance of SignatureParams
 func NewSignatureParams() *SignatureParams {
 	return &SignatureParams{}
 }
@@ -356,6 +365,7 @@ func NewSignatureParams() *SignatureParams {
 type CredentialSignature Handle
 type CredentialSignatureCorrectnessProof Handle
 
+// CredentialSignatureFromJSON creates and returns credential signature from json
 func CredentialSignatureFromJSON(jsn []byte) (*CredentialSignature, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -369,6 +379,7 @@ func CredentialSignatureFromJSON(jsn []byte) (*CredentialSignature, error) {
 	return &CredentialSignature{handle}, nil
 }
 
+// CredentialSignatureCorrectnessProofFromJSON creates and returns credential signature correctness proof from json
 func CredentialSignatureCorrectnessProofFromJSON(jsn []byte) (*CredentialSignatureCorrectnessProof, error) {
 	var handle unsafe.Pointer
 	cjson := C.CString(string(jsn))
@@ -382,7 +393,7 @@ func CredentialSignatureCorrectnessProofFromJSON(jsn []byte) (*CredentialSignatu
 	return &CredentialSignatureCorrectnessProof{handle}, nil
 }
 
-//SignCredential signs credential values with primary keys only
+// SignCredential signs credential values with primary keys only
 func (r *SignatureParams) SignCredential() (*CredentialSignature, *CredentialSignatureCorrectnessProof, error) {
 	var credSignature, credSignatureCorrectnessProof unsafe.Pointer
 
@@ -428,6 +439,7 @@ func (r *CredentialSignature) ProcessCredentialSignature(values *CredentialValue
 	return nil
 }
 
+// Free deallocates credential signature instance
 func (r *CredentialSignature) Free() error {
 	result := C.ursa_cl_credential_signature_free(r.ptr)
 	if result.code != 0 {
@@ -437,6 +449,7 @@ func (r *CredentialSignature) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of credential signature
 func (r *CredentialSignature) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -449,6 +462,7 @@ func (r *CredentialSignature) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates credential signature correctness proof instance
 func (r *CredentialSignatureCorrectnessProof) Free() error {
 	result := C.ursa_cl_signature_correctness_proof_free(r.ptr)
 	if result.code != 0 {
@@ -458,6 +472,7 @@ func (r *CredentialSignatureCorrectnessProof) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of credential signature correctness proof
 func (r *CredentialSignatureCorrectnessProof) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -474,6 +489,21 @@ type BlindedCredentialSecretsHandle Handle
 type CredentialSecretsBlindingFactors Handle
 type BlindedCredentialSecretsCorrectnessProof Handle
 
+// CredentialSecretsBlindingFactorsFromJSON creates and returns credential secrets blinding factors from json
+func CredentialSecretsBlindingFactorsFromJSON(jsn []byte) (*CredentialSecretsBlindingFactors, error) {
+	var handle unsafe.Pointer
+	cjson := C.CString(string(jsn))
+	defer C.free(unsafe.Pointer(cjson))
+
+	result := C.ursa_cl_credential_secrets_blinding_factors_from_json(cjson, &handle)
+	if result.code != 0 {
+		return nil, ursaError(C.GoString(result.message))
+	}
+
+	return &CredentialSecretsBlindingFactors{handle}, nil
+}
+
+// ToJSON creates and returns JSON representation of blinded credental secrets
 func (r *BlindedCredentialSecretsHandle) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -486,6 +516,7 @@ func (r *BlindedCredentialSecretsHandle) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates blinded credential secrets instance
 func (r *BlindedCredentialSecretsHandle) Free() error {
 	result := C.ursa_cl_blinded_credential_secrets_free(r.ptr)
 	if result.code != 0 {
@@ -495,6 +526,7 @@ func (r *BlindedCredentialSecretsHandle) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of credential secrets blinding factors
 func (r *CredentialSecretsBlindingFactors) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -507,6 +539,7 @@ func (r *CredentialSecretsBlindingFactors) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates credential secrets blinding factors instance
 func (r *CredentialSecretsBlindingFactors) Free() error {
 	result := C.ursa_cl_credential_secrets_blinding_factors_free(r.ptr)
 	if result.code != 0 {
@@ -516,6 +549,7 @@ func (r *CredentialSecretsBlindingFactors) Free() error {
 	return nil
 }
 
+// ToJSON creates and returns JSON representation of blinded credential secrets correctness proof
 func (r *BlindedCredentialSecretsCorrectnessProof) ToJSON() ([]byte, error) {
 	var jsn *C.char
 
@@ -528,6 +562,7 @@ func (r *BlindedCredentialSecretsCorrectnessProof) ToJSON() ([]byte, error) {
 	return []byte(C.GoString(jsn)), nil
 }
 
+// Free deallocates blinded credential secrets correctness proof instance
 func (r *BlindedCredentialSecretsCorrectnessProof) Free() error {
 	result := C.ursa_cl_blinded_credential_secrets_correctness_proof_free(r.ptr)
 	if result.code != 0 {
@@ -543,6 +578,7 @@ type BlindedCredentialSecrets struct {
 	CorrectnessProof *BlindedCredentialSecretsCorrectnessProof
 }
 
+// BlindCredentialSecrets creates blinded credential secrets for given issuer key and master secret
 func BlindCredentialSecrets(credentialPubKey *CredentialDefPubKey, keyCorrectnessProof *CredentialDefKeyCorrectnessProof, nonce *Nonce,
 	values *CredentialValues) (*BlindedCredentialSecrets, error) {
 

--- a/pkg/libursa/ursa/ursa_cl.h
+++ b/pkg/libursa/ursa/ursa_cl.h
@@ -719,7 +719,7 @@ struct ExternError ursa_cl_credential_secrets_blinding_factors_free(const void *
  * * `credential_secrets_blinding_factors_json` - Reference that contains credential secrets blinding factors json.
  * * `credential_secrets_blinding_factors_p` - Reference that will contain credential secrets blinding factors instance pointer.
  */
-struct ExternErrorrrorCode ursa_cl_credential_secrets_blinding_factors_from_json(const char *credential_secrets_blinding_factors_json,
+struct ExternError ursa_cl_credential_secrets_blinding_factors_from_json(const char *credential_secrets_blinding_factors_json,
                                                                 const void **credential_secrets_blinding_factors_p);
 
 /**

--- a/pkg/libursa/ursa/ursa_test.go
+++ b/pkg/libursa/ursa/ursa_test.go
@@ -268,6 +268,38 @@ func TestBlindCredentialSecrets(t *testing.T) {
 	})
 }
 
+func TestBlindedSecrets(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		fields := []string{"attr1"}
+		nonfields := []string{"non-schema-attr1"}
+		vals := map[string]interface{}{
+			"attr1":            "val1",
+			"non-schema-attr1": "val2",
+		}
+
+		nonce, err := NewNonce()
+		assert.NoError(t, err)
+
+		credDef := createCredentialDefinition(t, fields, nonfields)
+		js, err := credDef.KeyCorrectnessProof.ToJSON()
+		assert.NoError(t, err)
+		assert.Contains(t, string(js), "\"attr1\"")
+		assert.Contains(t, string(js), "\"non-schema-attr1\"")
+
+		blindedSecrets := createBlindedSecrets(t, credDef, nonce, vals)
+
+		js, err = blindedSecrets.BlindingFactor.ToJSON()
+		assert.NoError(t, err)
+
+		assert.Contains(t, string(js), "\"v_prime\"")
+
+		bf, err := CredentialSecretsBlindingFactorsFromJSON(js)
+		assert.NoError(t, err)
+		assert.NotNil(t, bf)
+
+	})
+}
+
 func createBlindedSecrets(t *testing.T, credDef *CredentialDef, nonce *Nonce, vals map[string]interface{}) *BlindedCredentialSecrets {
 
 	values := createValues(t, vals)

--- a/pkg/libursa/ursa/value_builder.go
+++ b/pkg/libursa/ursa/value_builder.go
@@ -18,7 +18,7 @@ import (
 type CredentialValuesBuilder Handle
 type CredentialValues Handle
 
-// NewValuesBuilder creates and returns credentials values entity builder
+// NewValueBuilder creates and returns credentials values entity builder
 func NewValueBuilder() (*CredentialValuesBuilder, error) {
 	var builder unsafe.Pointer
 
@@ -79,7 +79,7 @@ func (r *CredentialValuesBuilder) AddDecCommitment(attr, decValue, decBlindingFa
 	return nil
 }
 
-// FinalizeBuilder deallocates credential values builder and returns credential values entity instead
+// Finalize deallocates credential values builder and returns credential values entity instead
 func (r *CredentialValuesBuilder) Finalize() (*CredentialValues, error) {
 	var values unsafe.Pointer
 	result := C.ursa_cl_credential_values_builder_finalize(r.ptr, &values)
@@ -90,7 +90,7 @@ func (r *CredentialValuesBuilder) Finalize() (*CredentialValues, error) {
 	return &CredentialValues{values}, nil
 }
 
-// FreeCredentialValues deallocates credential values instance
+// Free deallocates credential values instance
 func (r *CredentialValues) Free() error {
 	result := C.ursa_cl_credential_values_free(r.ptr)
 	if result.code != 0 {
@@ -100,6 +100,7 @@ func (r *CredentialValues) Free() error {
 	return nil
 }
 
+// EncodeValue encodes any value into decimal representation
 func EncodeValue(val interface{}) (string, string) {
 	var raw, enc string
 
@@ -159,6 +160,7 @@ func EncodeValue(val interface{}) (string, string) {
 	return raw, enc
 }
 
+// ToEncodedNumber encodes string to decimal encoded value
 func ToEncodedNumber(raw string) string {
 	b := []byte(raw)
 	hasher := sha256.New()

--- a/pkg/libursa/ursa/verifier.go
+++ b/pkg/libursa/ursa/verifier.go
@@ -8,6 +8,7 @@ package ursa
 import "C"
 
 import (
+	"errors"
 	"unsafe"
 )
 
@@ -26,16 +27,20 @@ func NewProofVerifier() (*ProofVerifier, error) {
 }
 
 // Verify verifies proof and deallocates proof verifier.
-func (r *ProofVerifier) Verify(proof *ProofHandle, nonce *Nonce) (bool, error) {
+func (r *ProofVerifier) Verify(proof *ProofHandle, nonce *Nonce) error {
 	var verified C.bool
 
 	result := C.ursa_cl_proof_verifier_verify(r.ptr, proof.ptr, nonce.ptr, &verified)
 	if result.code != 0 {
-		return false, ursaError(C.GoString(result.message))
+		return ursaError(C.GoString(result.message))
 	}
 
 	out := bool(verified)
-	return out, nil
+	if !out {
+		return errors.New("invalid proof")
+	}
+
+	return nil
 }
 
 // AddCommonAttribute add a common attribute to the proof verifier

--- a/pkg/libursa/ursa/verifier_test.go
+++ b/pkg/libursa/ursa/verifier_test.go
@@ -98,8 +98,7 @@ func TestVerifierVerify(t *testing.T) {
 		err = verifier.AddSubProofRequest(subProofRequest, schema, nonSchema, credDef.PubKey)
 		assert.NoError(t, err)
 
-		verified, err := verifier.Verify(proof, proofRequestNonce)
+		err = verifier.Verify(proof, proofRequestNonce)
 		assert.NoError(t, err)
-		assert.True(t, verified)
 	})
 }


### PR DESCRIPTION
This PR container:

- Final wrapped method needed to round trip Indy credentials in Go
- Comments for all public methods, carried forward from the original Rust comments.

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>
