### PR TITLE
Credential values serialization/deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .idea/
 coverage.txt
 *.out
+.vscode/

--- a/pkg/libursa/ursa/ursa_cl.h
+++ b/pkg/libursa/ursa/ursa_cl.h
@@ -418,6 +418,26 @@ struct ExternError ursa_cl_credential_values_builder_finalize(const void *creden
 struct ExternError ursa_cl_credential_values_builder_new(const void **credential_values_builder_p);
 
 /**
+ * Creates and returns credential values json.
+ *
+ * Note: Credential values instance deallocation must be performed by calling ursa_cl_credential_values_free.
+ *
+ * # Arguments
+ * * `credential_values_json` - Reference that contains credential values json.
+ * * `credential_values_p` - Reference that will contain credential values instance pointer.
+ */
+struct ExternError ursa_cl_credential_values_from_json(const char *credential_values_json, const void **credential_values_p);
+
+/**
+ * Returns json representation of credential values.
+ *
+ * # Arguments
+ * * `credential_values` - Reference that contains credential values instance pointer.
+ * * `credential_values_json_p` - Reference that will contain credential values json.
+ */
+struct ExternError ursa_cl_credential_values_to_json(const void *credential_values, const char **credential_values_json_p);
+
+/**
  * Deallocates credential values instance.
  *
  * # Arguments

--- a/pkg/libursa/ursa/value_builder_test.go
+++ b/pkg/libursa/ursa/value_builder_test.go
@@ -11,6 +11,22 @@ func TestNewValueBuilder(t *testing.T) {
 		builder, err := NewValueBuilder()
 		assert.Empty(t, err)
 		assert.NotEmpty(t, builder)
+
+		err = builder.AddDecHidden("master_secret", "122345")
+		assert.NoError(t, err)
+
+		vals, err := builder.Finalize()
+		assert.NoError(t, err)
+
+		str, err := vals.ToJSON()
+		assert.NoError(t, err)
+
+		err = vals.Free()
+		assert.NoError(t, err)
+
+		newVals, err := CredentialValuesFromJSON(str)
+		assert.NoError(t, err)
+		assert.NotNil(t, newVals)
 	})
 }
 


### PR DESCRIPTION
**Credential values serialization/deserialization:**

**Description:**
Changes to support json for CredValues related to https://github.com/hyperledger/ursa/pull/210 changes in `ursa`

Summary:

* added toJson/fromJson methods for Credential Values to the header file
* added Golang wrappers for the methods
* updated related test
