### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -45,13 +45,13 @@ RUN cd /usr/lib/x86_64-linux-gnu \
 
 RUN git clone https://github.com/hyperledger/ursa.git \
      && cd ursa \
-     && git checkout bbs-v0.4.0 \
+     && cd libursa \
      && cargo build --release \
      && cp target/release/*.so /usr/local/lib/
 
 RUN git clone https://github.com/mattrglobal/ffi-bbs-signatures.git \
      && cd ffi-bbs-signatures \
-     && git checkout master \
+     && git checkout 6fe88357938f144c43f67085b1c3c31b6656f39f \
      && cargo build --release \
      && cp target/release/libbbs.so /usr/local/lib/
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,63 +2,62 @@ name: Build
 on: [ push, pull_request ]
 
 jobs:
-# TODO: enable back once fixing the secrets
-#  workflow-setup:
-#    runs-on: ubuntu-latest
-#    outputs:
-#      CACHE_KEY_IMAGE: ${{ steps.cache.outputs.CACHE_KEY_IMAGE }}
-#    steps:
-#      - name: Git checkout
-#        uses: actions/checkout@v2
-#      - name: Set outputs
-#        id: cache
-#        run: |
-#          echo "::set-output name=CACHE_KEY_IMAGE::${{ hashFiles('.github/workflows/Dockerfile') }}"
+  workflow-setup:
+    runs-on: ubuntu-latest
+    outputs:
+      CACHE_KEY_IMAGE: ${{ steps.cache.outputs.CACHE_KEY_IMAGE }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Set outputs
+        id: cache
+        run: |
+          echo "::set-output name=CACHE_KEY_IMAGE::${{ hashFiles('.github/workflows/Dockerfile') }}"
 
-#  build-image:
-#    needs: workflow-setup
-#    runs-on: ubuntu-latest
-#    env:
-#      DOCKER_BUILDKIT: 1
-#      CACHE_KEY_IMAGE: ${{ needs.workflow-setup.outputs.CACHE_KEY_IMAGE }}
-#    steps:
-#      - name: Git checkout
-#        uses: actions/checkout@v2
-#      - name: Try load from cache.
-#        id: cache-image
-#        uses: actions/cache@v2
-#        with:
-#          path: ${GITHUB_WORKSPACE}/cache
-#          key: ${{ env.CACHE_KEY_IMAGE}}
-#      - name: If NOT found in cache, build and push image.
-#        if: steps.cache-image.outputs.cache-hit != 'true'
-#        run: |
-#          echo ${{ secrets.CR_PAT }} | docker login ghcr.io --username ${{ secrets.CR_USER }} --password-stdin
-#          docker build -f .github/workflows/Dockerfile --no-cache -t ${GITHUB_REPOSITORY}/uwg-build:${{ env.CACHE_KEY_IMAGE }} .
-#          docker tag ${GITHUB_REPOSITORY}/uwg-build:${{ env.CACHE_KEY_IMAGE }} ghcr.io/${GITHUB_REPOSITORY}/uwg-build:latest
-#          docker push ghcr.io/${GITHUB_REPOSITORY}/uwg-build:latest
-#          mkdir -p ${GITHUB_WORKSPACE}/cache
-#          touch ${GITHUB_WORKSPACE}/cache/${{ env.CACHE_KEY_IMAGE }}
-        
+  build-image:
+    needs: workflow-setup
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+      CACHE_KEY_IMAGE: ${{ needs.workflow-setup.outputs.CACHE_KEY_IMAGE }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Try load from cache.
+        id: cache-image
+        uses: actions/cache@v2
+        with:
+          path: ${GITHUB_WORKSPACE}/cache
+          key: ${{ env.CACHE_KEY_IMAGE}}
+      - name: If NOT found in cache, build and push image.
+        if: steps.cache-image.outputs.cache-hit != 'true'
+        run: |
+          echo ${{ secrets.CR_PAT }} | docker login ghcr.io --username ${{ secrets.CR_USER }} --password-stdin
+          docker build -f .github/workflows/Dockerfile --no-cache -t ${GITHUB_REPOSITORY}/uwg-build:${{ env.CACHE_KEY_IMAGE }} .
+          docker tag ${GITHUB_REPOSITORY}/uwg-build:${{ env.CACHE_KEY_IMAGE }} ghcr.io/${GITHUB_REPOSITORY}/uwg-build:latest
+          docker push ghcr.io/${GITHUB_REPOSITORY}/uwg-build:latest
+          mkdir -p ${GITHUB_WORKSPACE}/cache
+          touch ${GITHUB_WORKSPACE}/cache/${{ env.CACHE_KEY_IMAGE }}
+
   test:
     name: Test using Ursa
-    # needs: build-image
+    needs: build-image
     runs-on: ubuntu-20.04
     container:
-     image: ghcr.io/${{ github.repository }}/uwg-build
+      image: ghcr.io/${{ github.repository }}/uwg-build
     strategy:
       matrix:
         go-version: [1.14, 1.15]
     steps:
-    - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-      id: go
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-    - name: Test using Ursa ${{ matrix.ursa-version }}
-      run: |
-        make test
+      - name: Test using Ursa ${{ matrix.ursa-version }}
+        run: |
+          make test


### PR DESCRIPTION
**Title:**
Fix back the CI to build the latest main Ursa Docker image

**Note:**
Currently branch-based approach should be used for PRs in ursa-wrapper-go repo, as access to secrets is expected. Forks don't have access to repo secrets. 