### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,12 +5,17 @@ Maintainers
 
 | Name | GitHub | Chat                       |
 |------|--------|----------------------------|
+| Alexander Shcherbakov | [ashcherbakov][ashcherbakov] | alexander.shcherbakov#5576 |
+| Konstantin Goncharov | [kgoncharov][kgoncharov] |          |
+
+**Emeritus Maintainers**
+
+| Name | GitHub | Chat                       |
+|------|--------|----------------------------|
 | Kevin Griffin | [m00sey][m00sey] |                   |
 | Michael Lodder | [mikelodder7][mikelodder7] |           |
 | Philip Feairheller | [pfeairheller][pfeairheller] |      |
 | Sergey Minaev | [jovfer][jovfer] |               |
-| Konstantin Goncharov | [kgoncharov][kgoncharov] |          |
-| Alexander Shcherbakov | [ashcherbakov][ashcherbakov] | alexander.shcherbakov#5576 |
 
 [m00sey]: https://github.com/m00sey
 [mikelodder7]: https://github.com/mikelodder7


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>